### PR TITLE
add bootnodes by Gatotech

### DIFF
--- a/chain-specs/paseo.plain.json
+++ b/chain-specs/paseo.plain.json
@@ -4,7 +4,9 @@
   "chainType": "Live",
   "bootNodes": [
     "/dns/paseo.bootnode.amforc.com/tcp/30333/wss/p2p/12D3KooWFD81HC9memUwuGMLvhDDEfmXjn6jC4n7zyNs3vToXapS",
-    "/dns/paseo.bootnode.amforc.com/tcp/30344/p2p/12D3KooWFD81HC9memUwuGMLvhDDEfmXjn6jC4n7zyNs3vToXapS"
+    "/dns/paseo.bootnode.amforc.com/tcp/30344/p2p/12D3KooWFD81HC9memUwuGMLvhDDEfmXjn6jC4n7zyNs3vToXapS",
+    "/dns/boot.gatotech.network/tcp/33400/p2p/12D3KooWEvz5Ygv3MhCUNTVQbUTVhzhvf4KKcNoe5M5YbVLPBeeW",
+    "/dns/boot.gatotech.network/tcp/35400/wss/p2p/12D3KooWEvz5Ygv3MhCUNTVQbUTVhzhvf4KKcNoe5M5YbVLPBeeW"
   ],
   "telemetryEndpoints": null,
   "protocolId": "pas",

--- a/chain-specs/paseo.raw.json
+++ b/chain-specs/paseo.raw.json
@@ -4,7 +4,9 @@
   "chainType": "Live",
   "bootNodes": [
     "/dns/paseo.bootnode.amforc.com/tcp/30333/wss/p2p/12D3KooWFD81HC9memUwuGMLvhDDEfmXjn6jC4n7zyNs3vToXapS",
-    "/dns/paseo.bootnode.amforc.com/tcp/30344/p2p/12D3KooWFD81HC9memUwuGMLvhDDEfmXjn6jC4n7zyNs3vToXapS"
+    "/dns/paseo.bootnode.amforc.com/tcp/30344/p2p/12D3KooWFD81HC9memUwuGMLvhDDEfmXjn6jC4n7zyNs3vToXapS",
+    "/dns/boot.gatotech.network/tcp/33400/p2p/12D3KooWEvz5Ygv3MhCUNTVQbUTVhzhvf4KKcNoe5M5YbVLPBeeW",
+    "/dns/boot.gatotech.network/tcp/35400/wss/p2p/12D3KooWEvz5Ygv3MhCUNTVQbUTVhzhvf4KKcNoe5M5YbVLPBeeW"
   ],
   "telemetryEndpoints": null,
   "protocolId": "pas",


### PR DESCRIPTION
Dear team, 

Please consider this request to add the bootnodes available from Gatotech as part of the IBP collective.

These endpoints were tested using a modified `paseo.json` chainspec (bootnodes removed), and passing the `--bootnodes` flag manually, like below:

```
# endpoint for peer-to-peer (P2P) connection
polkadot --no-hardware-benchmarks --no-mdns --chain paseo.json --bootnodes "/dns/boot.gatotech.network/tcp/33400/p2p/12D3KooWEvz5Ygv3MhCUNTVQbUTVhzhvf4KKcNoe5M5YbVLPBeeW"

# endpoint for Secured Websocket (WSS) connection
polkadot --no-hardware-benchmarks --no-mdns --chain paseo.json --bootnodes "/dns/boot.gatotech.network/tcp/35400/wss/p2p/12D3KooWEvz5Ygv3MhCUNTVQbUTVhzhvf4KKcNoe5M5YbVLPBeeW"
```

Many thanks!

Best regards!!

Milos