### PR TITLE
Add Bob to get Paseo-Local to onboard parachains

### DIFF
--- a/chain-spec-generator/src/relay_chain_specs.rs
+++ b/chain-spec-generator/src/relay_chain_specs.rs
@@ -271,7 +271,7 @@ fn paseo_local_genesis(wasm_binary: &[u8]) -> paseo_runtime::RuntimeGenesisConfi
     paseo_genesis(
         wasm_binary,
         // initial authorities
-        vec![get_authority_keys_from_seed("Alice")],
+        vec![get_authority_keys_from_seed("Alice"), get_authority_keys_from_seed("Bob")],
         //root key
         get_account_id_from_seed::<sr25519::Public>("Alice"),
         // endowed accounts


### PR DESCRIPTION
To get Paseo Local to onboard parachains requires new eras to start and they cannot start by default without a second validator.

This adds Bob to the Alice validator in the same way as Rococo Local has.