### PR TITLE
Update build-runtime.yaml

### DIFF
--- a/.github/workflows/build-runtime.yaml
+++ b/.github/workflows/build-runtime.yaml
@@ -16,9 +16,9 @@ jobs:
           - name: "paseo"
             path: "relay/paseo"
           - name: "asset-hub-paseo"
-            path: "system-parachains/asset-hub-paseo"
+            path: "system-parachains/asset-hub-paseo-runtime"
           - name: "bridge-hub-paseo"
-            path: "system-parachains/bridge-hub-paseo"
+            path: "system-parachains/bp-bridge-hub-paseo"
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4


### PR DESCRIPTION
runtime crates were correctly named in the yaml file.