### PR TITLE
fix: system parachain chain spec generator

### DIFF
--- a/chain-spec-generator/src/system_parachains_specs.rs
+++ b/chain-spec-generator/src/system_parachains_specs.rs
@@ -47,8 +47,8 @@ pub fn asset_hub_paseo_local_testnet_config() -> Result<Box<dyn ChainSpec>, Stri
 			asset_hub_paseo_runtime::WASM_BINARY.expect("AssetHubPaseo wasm not available!"),
 			Extensions { relay_chain: "paseo-local".into(), para_id: 1000 },
 		)
-		.with_name("Paseo Asset Hub Local")
-		.with_id("paseo-asset-hub-local")
+		.with_name("Asset Hub Paseo Local")
+		.with_id("asset-hub-paseo-local")
 		.with_chain_type(ChainType::Local)
 		.with_protocol_id("ah-pas")
 		.with_genesis_config_patch(


### PR DESCRIPTION
When running `pop up parachain` with the latest paseo release (`v1.3.1`) I was getting an issue generating the chain-spec. Comparing the old one generated (`v1.2.6`) with the new one I noticed the difference was with the id:
```
"name": "Asset Hub Paseo Local",
"id": "asset-hub-paseo-local"
```
vs

```
“name": "Paseo Asset Hub Local",
"id": "paseo-asset-hub-local",
```
Fixed to use `asset-hub-paseo-local`.