### PR TITLE
fix: add sudo weights to system chains

### DIFF
--- a/system-parachains/bridge-hub-paseo/src/lib.rs
+++ b/system-parachains/bridge-hub-paseo/src/lib.rs
@@ -516,7 +516,7 @@ impl pallet_utility::Config for Runtime {
 impl pallet_sudo::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeCall = RuntimeCall;
-	type WeightInfo = weights::pallet_sudo::WeightInfo<Runtime>;
+	type WeightInfo = pallet_sudo::weights::SubstrateWeight<Runtime>;
 }
 
 // Create the runtime by composing the FRAME pallets that were previously configured.

--- a/system-parachains/coretime-paseo/src/lib.rs
+++ b/system-parachains/coretime-paseo/src/lib.rs
@@ -600,7 +600,7 @@ impl pallet_utility::Config for Runtime {
 impl pallet_sudo::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeCall = RuntimeCall;
-	type WeightInfo = weights::pallet_sudo::WeightInfo<Runtime>;
+	type WeightInfo = pallet_sudo::weights::SubstrateWeight<Runtime>;
 }
 
 // Create the runtime by composing the FRAME pallets that were previously configured.
@@ -637,7 +637,7 @@ construct_runtime!(
 
 		// The main stage.
 		Broker: pallet_broker = 50,
-		
+
 		// Sudo.
 		Sudo: pallet_sudo::{Pallet, Call, Storage, Event<T>, Config<T>} = 255,
 	}

--- a/system-parachains/people-paseo/src/lib.rs
+++ b/system-parachains/people-paseo/src/lib.rs
@@ -535,7 +535,7 @@ impl pallet_utility::Config for Runtime {
 impl pallet_sudo::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeCall = RuntimeCall;
-	type WeightInfo = weights::pallet_sudo::WeightInfo<Runtime>;
+	type WeightInfo = pallet_sudo::weights::SubstrateWeight<Runtime>;
 }
 
 // Create the runtime by composing the FRAME pallets that were previously configured.


### PR DESCRIPTION
Sudo weights were left out in 03f08f7902433a68d45c6f44284c1b570b77c5c7. This configures the pallet to use the crate weights.

Should be alright.