### PR TITLE
refactor(spec-generator): use genesis presets

### DIFF
--- a/chain-spec-generator/src/relay_chain_specs.rs
+++ b/chain-spec-generator/src/relay_chain_specs.rs
@@ -43,9 +43,7 @@ pub fn paseo_development_config() -> Result<Box<dyn ChainSpec>, String> {
 		.with_id("paseo-dev")
 		.with_chain_type(ChainType::Development)
 		.with_protocol_id("pas")
-		.with_genesis_config_patch(
-			paseo_runtime::genesis_config_presets::paseo_development_config_genesis(),
-		)
+		.with_genesis_config_preset_name("development")
 		.with_protocol_id(DEFAULT_PROTOCOL_ID)
 		.with_properties(paseo_chain_spec_properties())
 		.build(),
@@ -63,9 +61,7 @@ pub fn paseo_local_testnet_config() -> Result<Box<dyn ChainSpec>, String> {
 		.with_id("paseo-local")
 		.with_chain_type(ChainType::Local)
 		.with_protocol_id("pas")
-		.with_genesis_config_patch(
-			paseo_runtime::genesis_config_presets::paseo_local_testnet_genesis(),
-		)
+		.with_genesis_config_preset_name("local_testnet")
 		.with_protocol_id(DEFAULT_PROTOCOL_ID)
 		.with_properties(paseo_chain_spec_properties())
 		.build(),

--- a/chain-spec-generator/src/system_parachains_specs.rs
+++ b/chain-spec-generator/src/system_parachains_specs.rs
@@ -53,6 +53,7 @@ pub fn asset_hub_paseo_local_testnet_config() -> Result<Box<dyn ChainSpec>, Stri
 		.with_id("asset-hub-paseo-local")
 		.with_chain_type(ChainType::Local)
 		.with_genesis_config_preset_name("local_testnet")
+		.with_protocol_id("ah-pas")
 		.with_properties(properties)
 		.build(),
 	))
@@ -74,11 +75,7 @@ pub fn bridge_hub_paseo_local_testnet_config() -> Result<Box<dyn ChainSpec>, Str
 		.with_id("paseo-bridge-hub-local")
 		.with_chain_type(ChainType::Local)
 		.with_protocol_id("bh-pas")
-		.with_genesis_config_patch(
-		    bridge_hub_paseo_runtime::genesis_config_presets::bridge_hub_paseo_local_testnet_genesis(
-				1002.into()
-			),
-		)
+		.with_genesis_config_preset_name("local_testnet")
 		.with_properties(properties)
 		.build(),
 	))
@@ -99,11 +96,7 @@ pub fn people_paseo_local_testnet_config() -> Result<Box<dyn ChainSpec>, String>
 		.with_id("paseo-people-local")
 		.with_chain_type(ChainType::Local)
 		.with_protocol_id("pc-pas")
-		.with_genesis_config_patch(
-			people_paseo_runtime::genesis_config_presets::people_paseo_local_testnet_genesis(
-				1004.into(),
-			),
-		)
+		.with_genesis_config_preset_name("local_testnet")
 		.with_properties(properties)
 		.build(),
 	))


### PR DESCRIPTION
Fixes for #164 
Use available genesis presets in the chain spec generator