### PR TITLE
feat(ci): build collectives runtime & bump srtool version

### DIFF
--- a/.github/workflows/build-release-manual.yaml
+++ b/.github/workflows/build-release-manual.yaml
@@ -23,7 +23,9 @@ jobs:
             path: "system-parachains/people-paseo"
           - name: "coretime-paseo"
             path: "system-parachains/coretime-paseo"
-            
+          - name: "collecives-paseo"
+            path: "system-parachains/collectives-paseo"
+
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -39,7 +41,7 @@ jobs:
 
       - name: Build ${{ matrix.runtime.name }} runtime
         id: srtool_build
-        uses: chevdor/srtool-actions@v0.9.1
+        uses: chevdor/srtool-actions@v0.9.2
         env:
           BUILD_OPTS: "--features on-chain-release-build"
         with:

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -12,7 +12,7 @@ jobs:
   generate-chain-specs:
     uses: ./.github/workflows/generate-chain-specs.yaml
     permissions:
-      contents: write 
+      contents: write
       packages: write
     with:
       tag_version: ${{ github.event.inputs.tag_version }}
@@ -58,6 +58,8 @@ jobs:
             path: "system-parachains/people-paseo"
           - name: "coretime-paseo"
             path: "system-parachains/coretime-paseo"
+          - name: "collecives-paseo"
+            path: "system-parachains/collectives-paseo"
 
     steps:
       - name: Checkout sources
@@ -76,7 +78,7 @@ jobs:
 
       - name: Build ${{ matrix.runtime.name }} runtime
         id: srtool_build
-        uses: chevdor/srtool-actions@v0.9.1
+        uses: chevdor/srtool-actions@v0.9.2
         env:
           BUILD_OPTS: "--features on-chain-release-build"
         with:

--- a/.github/workflows/generate-chain-specs.yaml
+++ b/.github/workflows/generate-chain-specs.yaml
@@ -36,13 +36,13 @@ jobs:
       - name: Setup Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.77.0
+          toolchain: 1.81.0
           target: wasm32-unknown-unknown
           components: rust-src
           override: true
 
       - name: Add rust-src
-        run: rustup component add rust-src --toolchain 1.77.0-x86_64-unknown-linux-gnu
+        run: rustup component add rust-src --toolchain 1.81.0-x86_64-unknown-linux-gnu
 
       - name: Build chain-spec-generator
         run: cargo build --package chain-spec-generator --features=fast-runtime --release


### PR DESCRIPTION
Fixes for #164 
Adds collectives runtime to the build CI and updates `chevdor/srtool-actions` to use latest release.