### PR TITLE
feat(spec-generator): introduce collectives in spec generator

### DIFF
--- a/.github/workflows/build-release-manual.yaml
+++ b/.github/workflows/build-release-manual.yaml
@@ -23,7 +23,9 @@ jobs:
             path: "system-parachains/people-paseo"
           - name: "coretime-paseo"
             path: "system-parachains/coretime-paseo"
-            
+          - name: "collecives-paseo"
+            path: "system-parachains/collectives-paseo"
+
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -39,7 +41,7 @@ jobs:
 
       - name: Build ${{ matrix.runtime.name }} runtime
         id: srtool_build
-        uses: chevdor/srtool-actions@v0.9.1
+        uses: chevdor/srtool-actions@v0.9.2
         env:
           BUILD_OPTS: "--features on-chain-release-build"
         with:

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -12,7 +12,7 @@ jobs:
   generate-chain-specs:
     uses: ./.github/workflows/generate-chain-specs.yaml
     permissions:
-      contents: write 
+      contents: write
       packages: write
     with:
       tag_version: ${{ github.event.inputs.tag_version }}
@@ -58,6 +58,8 @@ jobs:
             path: "system-parachains/people-paseo"
           - name: "coretime-paseo"
             path: "system-parachains/coretime-paseo"
+          - name: "collecives-paseo"
+            path: "system-parachains/collectives-paseo"
 
     steps:
       - name: Checkout sources
@@ -76,7 +78,7 @@ jobs:
 
       - name: Build ${{ matrix.runtime.name }} runtime
         id: srtool_build
-        uses: chevdor/srtool-actions@v0.9.1
+        uses: chevdor/srtool-actions@v0.9.2
         env:
           BUILD_OPTS: "--features on-chain-release-build"
         with:

--- a/.github/workflows/generate-chain-specs.yaml
+++ b/.github/workflows/generate-chain-specs.yaml
@@ -36,13 +36,13 @@ jobs:
       - name: Setup Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.77.0
+          toolchain: 1.81.0
           target: wasm32-unknown-unknown
           components: rust-src
           override: true
 
       - name: Add rust-src
-        run: rustup component add rust-src --toolchain 1.77.0-x86_64-unknown-linux-gnu
+        run: rustup component add rust-src --toolchain 1.81.0-x86_64-unknown-linux-gnu
 
       - name: Build chain-spec-generator
         run: cargo build --package chain-spec-generator --features=fast-runtime --release

--- a/chain-spec-generator/Cargo.toml
+++ b/chain-spec-generator/Cargo.toml
@@ -18,6 +18,7 @@ asset-hub-paseo-runtime = { path = "../system-parachains/asset-hub-paseo", defau
 bridge-hub-paseo-runtime = { path = "../system-parachains/bridge-hub-paseo", default-features = true }
 people-paseo-runtime = { path = "../system-parachains/people-paseo", default-features = true }
 coretime-paseo-runtime = { path = "../system-parachains/coretime-paseo", default-features = true }
+collectives-paseo-runtime = { path = "../system-parachains/collectives-paseo", default-features = true }
 
 system-parachains-constants = { path = "../system-parachains/constants", default-features = true }
 

--- a/chain-spec-generator/src/common.rs
+++ b/chain-spec-generator/src/common.rs
@@ -16,10 +16,10 @@
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::{
-	relay_chain_specs::{PaseoChainSpec},
+	relay_chain_specs::PaseoChainSpec,
 	system_parachains_specs::{
-		AssetHubPaseoChainSpec,
-		BridgeHubPaseoChainSpec,CoretimePaseoChainSpec,PeoplePaseoChainSpec,
+		AssetHubPaseoChainSpec, BridgeHubPaseoChainSpec, CollectivesPaseoChainSpec,
+		CoretimePaseoChainSpec, PeoplePaseoChainSpec,
 	},
 	ChainSpec,
 };
@@ -36,16 +36,24 @@ pub fn from_json_file(filepath: &str, supported: String) -> Result<Box<dyn Chain
 	let chain_spec: EmptyChainSpecWithId = serde_json::from_reader(reader)
 		.expect("Failed to read 'json' file with ChainSpec configuration");
 	match &chain_spec.id {
-		x if x.eq("paseo") | x.eq("paseo-local") | x.eq("paseo-dev") =>
-			Ok(Box::new(PaseoChainSpec::from_json_file(path)?)),
-		x if x.starts_with("asset-hub-paseo") =>
-			Ok(Box::new(AssetHubPaseoChainSpec::from_json_file(path)?)),
-		x if x.starts_with("paseo-bridge-hub") =>
-			Ok(Box::new(BridgeHubPaseoChainSpec::from_json_file(path)?)),
-		x if x.starts_with("paseo-coretime") =>
-			Ok(Box::new(CoretimePaseoChainSpec::from_json_file(path)?)),
-		x if x.starts_with("paseo-people") =>
-			Ok(Box::new(PeoplePaseoChainSpec::from_json_file(path)?)),
+		x if x.eq("paseo") | x.eq("paseo-local") | x.eq("paseo-dev") => {
+			Ok(Box::new(PaseoChainSpec::from_json_file(path)?))
+		},
+		x if x.starts_with("asset-hub-paseo") => {
+			Ok(Box::new(AssetHubPaseoChainSpec::from_json_file(path)?))
+		},
+		x if x.starts_with("paseo-bridge-hub") => {
+			Ok(Box::new(BridgeHubPaseoChainSpec::from_json_file(path)?))
+		},
+		x if x.starts_with("paseo-coretime") => {
+			Ok(Box::new(CoretimePaseoChainSpec::from_json_file(path)?))
+		},
+		x if x.starts_with("paseo-people") => {
+			Ok(Box::new(PeoplePaseoChainSpec::from_json_file(path)?))
+		},
+		x if x.starts_with("collectives-people") => {
+			Ok(Box::new(CollectivesPaseoChainSpec::from_json_file(path)?))
+		},
 		_ => Err(format!("Unknown chain 'id' in json file. Only supported: {supported}'")),
 	}
 }

--- a/chain-spec-generator/src/common.rs
+++ b/chain-spec-generator/src/common.rs
@@ -51,7 +51,7 @@ pub fn from_json_file(filepath: &str, supported: String) -> Result<Box<dyn Chain
 		x if x.starts_with("paseo-people") => {
 			Ok(Box::new(PeoplePaseoChainSpec::from_json_file(path)?))
 		},
-		x if x.starts_with("collectives-people") => {
+		x if x.starts_with("paseo-collectives") => {
 			Ok(Box::new(CollectivesPaseoChainSpec::from_json_file(path)?))
 		},
 		_ => Err(format!("Unknown chain 'id' in json file. Only supported: {supported}'")),

--- a/chain-spec-generator/src/main.rs
+++ b/chain-spec-generator/src/main.rs
@@ -47,8 +47,7 @@ fn main() -> Result<(), String> {
 			),
 			(
 				"bridge-hub-paseo-local",
-				Box::new(system_parachains_specs::bridge_hub_paseo_local_testnet_config)
-					as Box<_>,
+				Box::new(system_parachains_specs::bridge_hub_paseo_local_testnet_config) as Box<_>,
 			),
 			(
 				"people-paseo-local",
@@ -65,6 +64,10 @@ fn main() -> Result<(), String> {
 			(
 				"coretime-paseo",
 				Box::new(|| system_parachains_specs::coretime_paseo_config()) as Box<_>,
+			),
+			(
+				"collectives-paseo-local",
+				Box::new(|| system_parachains_specs::collectives_paseo_local_config()) as Box<_>,
 			),
 		]);
 

--- a/chain-spec-generator/src/system_parachains_specs.rs
+++ b/chain-spec-generator/src/system_parachains_specs.rs
@@ -37,6 +37,7 @@ pub type BridgeHubPaseoChainSpec = sc_chain_spec::GenericChainSpec<Extensions>;
 pub type PeoplePaseoChainSpec = sc_chain_spec::GenericChainSpec<Extensions>;
 
 pub type CoretimePaseoChainSpec = sc_chain_spec::GenericChainSpec<Extensions>;
+pub type CollectivesPaseoChainSpec = sc_chain_spec::GenericChainSpec<Extensions>;
 
 pub fn asset_hub_paseo_local_testnet_config() -> Result<Box<dyn ChainSpec>, String> {
 	let mut properties = sc_chain_spec::Properties::new();
@@ -167,6 +168,27 @@ pub fn coretime_paseo_config() -> Result<Box<dyn ChainSpec>, String> {
 		.with_chain_type(ChainType::Live)
 		.with_protocol_id("ct-pas")
 		.with_genesis_config_preset_name("live")
+		.with_properties(properties)
+		.build(),
+	))
+}
+
+pub fn collectives_paseo_local_config() -> Result<Box<dyn ChainSpec>, String> {
+	let mut properties = sc_chain_spec::Properties::new();
+	properties.insert("ss58Format".into(), 0.into());
+	properties.insert("tokenSymbol".into(), "PAS".into());
+	properties.insert("tokenDecimals".into(), 10.into());
+
+	Ok(Box::new(
+		CollectivesPaseoChainSpec::builder(
+			collectives_paseo_runtime::WASM_BINARY.expect("Collectives wasm not available!"),
+			Extensions { relay_chain: "collectives-local".into(), para_id: 1001 },
+		)
+		.with_name("Paseo Collectives Local")
+		.with_id("paseo-collectives-local")
+		.with_chain_type(ChainType::Local)
+		.with_protocol_id("col-pas")
+		.with_genesis_config_preset_name("local_testnet")
 		.with_properties(properties)
 		.build(),
 	))


### PR DESCRIPTION
Relates to #164 
- [x] Add local config of collectives to chain-spec-generator
- [ ] ~~Add live config of collectives to chain-spec-generator.~~ Won't be done prior to the release of 1.4.0