### PR TITLE
Update the scheduling lookahead to be 3 for dev and local genesis to match Polkadot

### DIFF
--- a/relay/paseo/src/genesis_config_presets.rs
+++ b/relay/paseo/src/genesis_config_presets.rs
@@ -125,6 +125,7 @@ fn default_parachains_host_configuration() -> HostConfiguration<polkadot_primiti
 		scheduler_params: polkadot_primitives::SchedulerParams {
 			group_rotation_frequency: 20,
 			paras_availability_period: 4,
+			lookahead: 3,
 			..Default::default()
 		},
 		dispute_post_conclusion_acceptance_period: 100u32,


### PR DESCRIPTION
I'm not 100% sure this is correct as I'm not sure if we want it to be 3 on local and dev.

Also it changes it for regenerating the paseo mainnet genesis, but that would only happen if restarting the network.

Closes: #199 