### PR TITLE
chore: fix coretime price curve

### DIFF
--- a/.chopsticks/coretime.yml
+++ b/.chopsticks/coretime.yml
@@ -1,0 +1,13 @@
+endpoint: wss://sys.ibp.network/coretime-paseo
+mock-signature-host: true
+db: ./db.sqlite
+
+import-storage:
+  System:
+    Account:
+      - - - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+        - providers: 1
+          data:
+            free: 1000000000000000
+  Sudo:
+    Key: 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice

--- a/relay/paseo/src/lib.rs
+++ b/relay/paseo/src/lib.rs
@@ -1383,12 +1383,6 @@ impl paras_registrar::Config for Runtime {
 parameter_types! {
 	// 12 weeks = 3 months per lease period -> 8 lease periods ~ 2 years
 	pub LeasePeriod: BlockNumber = prod_or_fast!(1 * WEEKS, 1 * DAYS, "PAS_LEASE_PERIOD");
-	// Paseo Genesis was on May 26, 2020.
-	// Target Parachain Onboarding Date: Dec 15, 2021.
-	// Difference is 568 days.
-	// We want a lease period to start on the target onboarding date.
-	// 568 % (12 * 7) = 64 day offset
-	pub LeaseOffset: BlockNumber = prod_or_fast!(64 * DAYS, 0, "PAS_LEASE_OFFSET");
 }
 
 impl slots::Config for Runtime {

--- a/relay/paseo/src/lib.rs
+++ b/relay/paseo/src/lib.rs
@@ -1383,6 +1383,12 @@ impl paras_registrar::Config for Runtime {
 parameter_types! {
 	// 12 weeks = 3 months per lease period -> 8 lease periods ~ 2 years
 	pub LeasePeriod: BlockNumber = prod_or_fast!(1 * WEEKS, 1 * DAYS, "PAS_LEASE_PERIOD");
+	// Paseo Genesis was on May 26, 2020.
+	// Target Parachain Onboarding Date: Dec 15, 2021.
+	// Difference is 568 days.
+	// We want a lease period to start on the target onboarding date.
+	// 568 % (12 * 7) = 64 day offset
+	pub LeaseOffset: BlockNumber = prod_or_fast!(64 * DAYS, 0, "PAS_LEASE_OFFSET");
 }
 
 impl slots::Config for Runtime {

--- a/system-parachains/coretime-paseo/src/coretime.rs
+++ b/system-parachains/coretime-paseo/src/coretime.rs
@@ -375,15 +375,10 @@ impl<Balance: FixedPointOperand, MinPrice: Get<Balance>, TargetPrice: Get<Balanc
 	}
 
 	fn adapt_price(performance: SalePerformance<Balance>) -> AdaptedPrices<Balance> {
-		let mut proposal = CenterTargetPrice::<Balance>::adapt_price(performance);
-		let min_price = MinPrice::get();
+		let end_price = MinPrice::get();
 		let target_price = TargetPrice::get();
-		// Fix floor price:
-		proposal.end_price = min_price;
-		// Fix target price:
-		proposal.target_price = target_price;
 
-		proposal
+		AdaptedPrices { end_price, target_price }
 	}
 }
 #[cfg(test)]

--- a/system-parachains/coretime-paseo/src/coretime.rs
+++ b/system-parachains/coretime-paseo/src/coretime.rs
@@ -29,14 +29,15 @@ use frame_support::{
 };
 use frame_system::Pallet as System;
 use pallet_broker::{
-	AdaptPrice, AdaptedPrices, CoreAssignment, CoreIndex, CoretimeInterface, PartsOf57600,
-	RCBlockNumberOf, SalePerformance, TaskId,
+	AdaptPrice, AdaptedPrices, CenterTargetPrice, CoreAssignment, CoreIndex, CoretimeInterface,
+	PartsOf57600, RCBlockNumberOf, SalePerformance, TaskId,
 };
 use parachains_common::{AccountId, Balance};
 use paseo_runtime_constants::{system_parachain::coretime, time::DAYS as RELAY_DAYS};
+use sp_core::Get;
 use sp_runtime::{
 	traits::{AccountIdConversion, MaybeConvert},
-	FixedPointOperand, FixedU64, SaturatedConversion, Saturating,
+	FixedPointOperand, FixedU64,
 };
 use xcm::latest::prelude::*;
 use xcm_config::LocationToAccountId;
@@ -323,7 +324,8 @@ impl CoretimeInterface for CoretimeAllocator {
 parameter_types! {
 	pub const BrokerPalletId: PalletId = PalletId(*b"py/broke");
 	pub const MinimumCreditPurchase: Balance = UNITS / 10;
-	pub const MinimumEndPrice: Balance = 10 * UNITS;
+	pub const MinimumEndPrice: Balance = 500 * UNITS;
+	pub const FixedTargetPrice: Balance = 5000 * UNITS;
 }
 
 pub struct SovereignAccountOf;
@@ -349,29 +351,69 @@ impl pallet_broker::Config for Runtime {
 	type AdminOrigin = EnsureRoot<AccountId>;
 	type SovereignAccountOf = SovereignAccountOf;
 	type MaxAutoRenewals = ConstU32<100>;
-	type PriceAdapter = pallet_broker::MinimumPrice<Balance, MinimumEndPrice>;
+	type PriceAdapter =
+		MinimumPriceWithFixedTargetPrice<Balance, MinimumEndPrice, FixedTargetPrice>;
 	type MinimumCreditPurchase = MinimumCreditPurchase;
 }
 
-/// Simple implementation of `AdaptPrice` fitting the needs of a testnet environment.
-pub struct TestnetAdjustedAdapter<Balance>(core::marker::PhantomData<Balance>);
+/// `AdaptPrice` like `CenterTargetPrice`, but with an extra fixed target price and fixed floor
+/// price.
+///
+/// This price adapter behaves exactly like `CenterTargetPrice`, except that it takes a minimum
+/// price and a target price and makes sure that the returned `end_price` is never lower than that.
+///
+/// Target price is fixed and never adjusted based on the previous sale performance.
+pub struct MinimumPriceWithFixedTargetPrice<Balance, MinPrice, TargetPrice>(
+	core::marker::PhantomData<(Balance, MinPrice, TargetPrice)>,
+);
 
-impl<Balance: FixedPointOperand> AdaptPrice<Balance> for TestnetAdjustedAdapter<Balance> {
+impl<Balance: FixedPointOperand, MinPrice: Get<Balance>, TargetPrice: Get<Balance>>
+	AdaptPrice<Balance> for MinimumPriceWithFixedTargetPrice<Balance, MinPrice, TargetPrice>
+{
 	fn leadin_factor_at(when: FixedU64) -> FixedU64 {
-		if when <= FixedU64::from_rational(1, 2) {
-			FixedU64::from(100).saturating_sub(when.saturating_mul(180.into()))
-		} else {
-			FixedU64::from(19).saturating_sub(when.saturating_mul(18.into()))
-		}
+		CenterTargetPrice::<Balance>::leadin_factor_at(when)
 	}
 
-	fn adapt_price(_performance: SalePerformance<Balance>) -> AdaptedPrices<Balance> {
-		// Always return fixed prices regardless of previous sale performance
-		// Use the initial base price from configuration
+	fn adapt_price(performance: SalePerformance<Balance>) -> AdaptedPrices<Balance> {
+		let mut proposal = CenterTargetPrice::<Balance>::adapt_price(performance);
+		let min_price = MinPrice::get();
+		let target_price = TargetPrice::get();
+		// Fix floor price:
+		proposal.end_price = min_price;
+		// Fix target price:
+		proposal.target_price = target_price;
 
-		let end_price = Balance::saturated_from(5000 * UNITS);
-		let target_price = Balance::saturated_from(1000 * UNITS);
+		proposal
+	}
+}
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use pallet_broker::SaleInfoRecord;
 
-		AdaptedPrices { end_price, target_price }
+	#[test]
+	fn fixed_target_price_works() {
+		let paseo_end_price: Balance = 1005712197111515;
+		let paseo_sellout_price: Balance = 22197504910467441;
+
+		let sale_record = SaleInfoRecord {
+			sale_start: 0,
+			leadin_length: 0,
+			end_price: paseo_end_price,
+			region_begin: 0,
+			region_end: 1,
+			ideal_cores_sold: 0,
+			cores_offered: 0,
+			first_core: 0,
+			sellout_price: Some(paseo_sellout_price),
+			cores_sold: 0,
+		};
+		let performance = SalePerformance::from_sale(&sale_record);
+		let prices =
+			MinimumPriceWithFixedTargetPrice::<u128, MinimumEndPrice, FixedTargetPrice>::adapt_price(
+				performance,
+			);
+		assert_eq!(prices.end_price, MinimumEndPrice::get());
+		assert_eq!(prices.target_price, FixedTargetPrice::get());
 	}
 }


### PR DESCRIPTION
This PR changes the implementation of `pallet_broker::PriceAdapter` to fix the end price and the target price for every sale.

While we keep the auction model, where there is downward pressure - we remove how the previous sale performance would affect to the subsequent sale prices.

This should ease the DevEx around coretime in testnet.

<!-- ClickUpRef: 8699mvy3w -->
:link: [zboto Link](https://app.clickup.com/t/8699mvy3w)