### PR TITLE
release: 1.7.1+ah-migration/system-chains

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -803,7 +803,7 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "asset-hub-paseo-emulated-chain"
-version = "1.0.0"
+version = "1.7.1"
 dependencies = [
  "asset-hub-paseo-runtime",
  "cumulus-primitives-core",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "asset-hub-paseo-runtime"
-version = "1.0.0"
+version = "1.7.1"
 dependencies = [
  "asset-test-utils",
  "assets-common",
@@ -907,7 +907,7 @@ dependencies = [
  "staging-xcm-builder",
  "staging-xcm-executor",
  "substrate-wasm-builder",
- "system-parachains-constants 1.0.0",
+ "system-parachains-constants 1.7.1",
  "xcm-runtime-apis",
 ]
 
@@ -1363,12 +1363,12 @@ dependencies = [
  "scale-info",
  "sp-core",
  "staging-xcm 18.0.0",
- "system-parachains-constants 1.0.0 (git+https://github.com/polkadot-fellows/runtimes?tag=v1.7.1)",
+ "system-parachains-constants 1.0.0",
 ]
 
 [[package]]
 name = "bp-asset-hub-paseo"
-version = "1.0.0"
+version = "1.7.1"
 dependencies = [
  "bp-xcm-bridge-hub-router",
  "frame-support",
@@ -1376,7 +1376,7 @@ dependencies = [
  "scale-info",
  "sp-core",
  "staging-xcm 18.0.0",
- "system-parachains-constants 1.0.0",
+ "system-parachains-constants 1.7.1",
 ]
 
 [[package]]
@@ -1412,12 +1412,12 @@ dependencies = [
  "sp-api",
  "sp-runtime",
  "sp-std",
- "system-parachains-constants 1.0.0 (git+https://github.com/polkadot-fellows/runtimes?tag=v1.7.1)",
+ "system-parachains-constants 1.0.0",
 ]
 
 [[package]]
 name = "bp-bridge-hub-paseo"
-version = "1.0.0"
+version = "1.7.1"
 dependencies = [
  "bp-bridge-hub-cumulus",
  "bp-header-chain",
@@ -1432,7 +1432,7 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "staging-xcm 18.0.0",
- "system-parachains-constants 1.0.0",
+ "system-parachains-constants 1.7.1",
 ]
 
 [[package]]
@@ -1453,7 +1453,7 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "staging-xcm 18.0.0",
- "system-parachains-constants 1.0.0 (git+https://github.com/polkadot-fellows/runtimes?tag=v1.7.1)",
+ "system-parachains-constants 1.0.0",
 ]
 
 [[package]]
@@ -1644,7 +1644,7 @@ dependencies = [
 
 [[package]]
 name = "bridge-hub-paseo-emulated-chain"
-version = "1.0.0"
+version = "1.7.1"
 dependencies = [
  "bp-messages",
  "bridge-hub-common",
@@ -1659,7 +1659,7 @@ dependencies = [
 
 [[package]]
 name = "bridge-hub-paseo-integration-tests"
-version = "1.0.0"
+version = "1.7.1"
 dependencies = [
  "asset-hub-paseo-runtime",
  "bp-asset-hub-paseo",
@@ -1702,13 +1702,13 @@ dependencies = [
  "staging-xcm 18.0.0",
  "staging-xcm-builder",
  "staging-xcm-executor",
- "system-parachains-constants 1.0.0",
+ "system-parachains-constants 1.7.1",
  "xcm-runtime-apis",
 ]
 
 [[package]]
 name = "bridge-hub-paseo-runtime"
-version = "1.0.0"
+version = "1.7.1"
 dependencies = [
  "bp-asset-hub-kusama",
  "bp-asset-hub-paseo",
@@ -1811,7 +1811,7 @@ dependencies = [
  "staging-xcm-builder",
  "staging-xcm-executor",
  "substrate-wasm-builder",
- "system-parachains-constants 1.0.0",
+ "system-parachains-constants 1.7.1",
  "tuplex",
  "xcm-runtime-apis",
 ]
@@ -2066,7 +2066,7 @@ dependencies = [
 
 [[package]]
 name = "chain-spec-generator"
-version = "1.0.0"
+version = "1.7.1"
 dependencies = [
  "asset-hub-paseo-runtime",
  "bridge-hub-paseo-runtime",
@@ -2093,7 +2093,7 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "staging-xcm 8.0.1",
- "system-parachains-constants 1.0.0",
+ "system-parachains-constants 1.7.1",
 ]
 
 [[package]]
@@ -2221,7 +2221,7 @@ dependencies = [
 
 [[package]]
 name = "collectives-paseo-runtime"
-version = "1.0.0"
+version = "1.7.1"
 dependencies = [
  "collectives-paseo-runtime-constants",
  "collectives-polkadot-runtime-constants",
@@ -2296,13 +2296,13 @@ dependencies = [
  "staging-xcm-builder",
  "staging-xcm-executor",
  "substrate-wasm-builder",
- "system-parachains-constants 1.0.0",
+ "system-parachains-constants 1.7.1",
  "xcm-runtime-apis",
 ]
 
 [[package]]
 name = "collectives-paseo-runtime-constants"
-version = "1.0.0"
+version = "1.7.1"
 
 [[package]]
 name = "collectives-polkadot-runtime-constants"
@@ -2461,7 +2461,7 @@ dependencies = [
 
 [[package]]
 name = "coretime-paseo-emulated-chain"
-version = "1.0.0"
+version = "1.7.1"
 dependencies = [
  "coretime-paseo-runtime",
  "cumulus-primitives-core",
@@ -2473,7 +2473,7 @@ dependencies = [
 
 [[package]]
 name = "coretime-paseo-integration-tests"
-version = "1.0.0"
+version = "1.7.1"
 dependencies = [
  "asset-test-utils",
  "coretime-paseo-runtime",
@@ -2500,7 +2500,7 @@ dependencies = [
 
 [[package]]
 name = "coretime-paseo-runtime"
-version = "1.0.0"
+version = "1.7.1"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",
@@ -2564,7 +2564,7 @@ dependencies = [
  "staging-xcm-builder",
  "staging-xcm-executor",
  "substrate-wasm-builder",
- "system-parachains-constants 1.0.0",
+ "system-parachains-constants 1.7.1",
  "xcm-runtime-apis",
 ]
 
@@ -5265,7 +5265,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests-helpers"
-version = "1.0.0"
+version = "1.7.1"
 dependencies = [
  "asset-test-utils",
  "cumulus-pallet-xcmp-queue",
@@ -8524,7 +8524,7 @@ checksum = "7924d1d0ad836f665c9065e26d016c673ece3993f30d340068b16f282afc1156"
 
 [[package]]
 name = "paseo-emulated-chain"
-version = "1.0.0"
+version = "1.7.1"
 dependencies = [
  "emulated-integration-tests-common",
  "pallet-staking",
@@ -8542,7 +8542,7 @@ dependencies = [
 
 [[package]]
 name = "paseo-runtime"
-version = "1.0.0"
+version = "1.7.1"
 dependencies = [
  "approx",
  "binary-merkle-tree",
@@ -8649,7 +8649,7 @@ dependencies = [
 
 [[package]]
 name = "paseo-runtime-constants"
-version = "1.0.0"
+version = "1.7.1"
 dependencies = [
  "frame-support",
  "pallet-remote-proxy",
@@ -8667,7 +8667,7 @@ dependencies = [
 
 [[package]]
 name = "paseo-system-emulated-network"
-version = "1.0.0"
+version = "1.7.1"
 dependencies = [
  "asset-hub-paseo-emulated-chain",
  "bridge-hub-paseo-emulated-chain",
@@ -8719,7 +8719,7 @@ dependencies = [
 
 [[package]]
 name = "penpal-emulated-chain"
-version = "1.0.0"
+version = "1.7.1"
 dependencies = [
  "cumulus-primitives-core",
  "emulated-integration-tests-common",
@@ -8804,7 +8804,7 @@ dependencies = [
 
 [[package]]
 name = "people-paseo-emulated-chain"
-version = "1.0.0"
+version = "1.7.1"
 dependencies = [
  "cumulus-primitives-core",
  "emulated-integration-tests-common",
@@ -8818,7 +8818,7 @@ dependencies = [
 
 [[package]]
 name = "people-paseo-runtime"
-version = "1.0.0"
+version = "1.7.1"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",
@@ -8882,7 +8882,7 @@ dependencies = [
  "staging-xcm-builder",
  "staging-xcm-executor",
  "substrate-wasm-builder",
- "system-parachains-constants 1.0.0",
+ "system-parachains-constants 1.7.1",
  "xcm-runtime-apis",
 ]
 
@@ -10078,7 +10078,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "relay-common"
-version = "1.0.0"
+version = "1.7.1"
 dependencies = [
  "pallet-staking-reward-fn",
  "parity-scale-codec",
@@ -13332,21 +13332,6 @@ dependencies = [
 [[package]]
 name = "system-parachains-constants"
 version = "1.0.0"
-dependencies = [
- "frame-support",
- "parachains-common",
- "paseo-runtime-constants",
- "polkadot-core-primitives",
- "polkadot-primitives",
- "smallvec",
- "sp-core",
- "sp-runtime",
- "staging-xcm 18.0.0",
-]
-
-[[package]]
-name = "system-parachains-constants"
-version = "1.0.0"
 source = "git+https://github.com/polkadot-fellows/runtimes?tag=v1.7.1#18cbc8b3004f3cff44f6de053bb4220a9f85a7b1"
 dependencies = [
  "frame-support",
@@ -13355,6 +13340,21 @@ dependencies = [
  "polkadot-core-primitives",
  "polkadot-primitives",
  "polkadot-runtime-constants",
+ "smallvec",
+ "sp-core",
+ "sp-runtime",
+ "staging-xcm 18.0.0",
+]
+
+[[package]]
+name = "system-parachains-constants"
+version = "1.7.1"
+dependencies = [
+ "frame-support",
+ "parachains-common",
+ "paseo-runtime-constants",
+ "polkadot-core-primitives",
+ "polkadot-primitives",
  "smallvec",
  "sp-core",
  "sp-runtime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.0.0"
+version = "1.7.1"
 authors = ["Paseo Core Team"]
 edition = "2021"
 repository = "https://github.com/paseo-network/runtimes.git"

--- a/system-parachains/asset-hub-paseo/tests/tests.rs
+++ b/system-parachains/asset-hub-paseo/tests/tests.rs
@@ -20,9 +20,8 @@
 use asset_hub_paseo_runtime::{
 	xcm_config::{
 		bridging::{self, XcmBridgeHubRouterFeeAssetId},
-		CheckingAccount, DotLocation, GovernanceLocation, LocationToAccountId,
-		RelayTreasuryLocation, RelayTreasuryPalletAccount, StakingPot,
-		TrustBackedAssetsPalletLocation, XcmConfig,
+		CheckingAccount, DotLocation, LocationToAccountId, RelayTreasuryLocation,
+		RelayTreasuryPalletAccount, StakingPot, TrustBackedAssetsPalletLocation, XcmConfig,
 	},
 	AllPalletsWithoutSystem, AssetDeposit, Assets, Balances, Block, ExistentialDeposit,
 	ForeignAssets, ForeignAssetsInstance, MetadataDepositBase, MetadataDepositPerByte,
@@ -548,7 +547,7 @@ fn change_xcm_bridge_hub_router_base_fee_by_governance_works() {
 	>(
 		collator_session_keys(),
 		1000,
-		GovernanceOrigin::Location(GovernanceLocation::get()),
+		GovernanceOrigin::Origin(RuntimeOrigin::root()),
 		|| {
 			log::error!(
 				target: "bridges::estimate",
@@ -580,7 +579,7 @@ fn change_xcm_bridge_hub_router_byte_fee_by_governance_works() {
 	>(
 		collator_session_keys(),
 		1000,
-		GovernanceOrigin::Location(GovernanceLocation::get()),
+		GovernanceOrigin::Origin(RuntimeOrigin::root()),
 		|| {
 			(
 				bridging::XcmBridgeHubRouterByteFee::key().to_vec(),
@@ -614,7 +613,7 @@ fn change_xcm_bridge_hub_ethereum_base_fee_by_governance_works() {
 	>(
 		collator_session_keys(),
 		1000,
-		GovernanceOrigin::Location(GovernanceLocation::get()),
+		GovernanceOrigin::Origin(RuntimeOrigin::root()),
 		|| {
 			(
 				bridging::to_ethereum::BridgeHubEthereumBaseFee::key().to_vec(),
@@ -897,55 +896,4 @@ fn authorized_aliases_work() {
 				&local_alice
 			));
 		})
-}
-
-#[test]
-fn governance_authorize_upgrade_works() {
-	use paseo_runtime_constants::system_parachain::{ASSET_HUB_ID, COLLECTIVES_ID};
-
-	// no - random para
-	assert_err!(
-		parachains_runtimes_test_utils::test_cases::can_governance_authorize_upgrade::<
-			Runtime,
-			RuntimeOrigin,
-		>(GovernanceOrigin::Location(Location::new(1, Parachain(12334)))),
-		Either::Right(InstructionError { index: 0, error: XcmError::Barrier })
-	);
-	// no - AssetHub
-	assert_err!(
-		parachains_runtimes_test_utils::test_cases::can_governance_authorize_upgrade::<
-			Runtime,
-			RuntimeOrigin,
-		>(GovernanceOrigin::Location(Location::new(1, Parachain(ASSET_HUB_ID)))),
-		Either::Right(InstructionError { index: 0, error: XcmError::Barrier })
-	);
-	// no - Collectives
-	assert_err!(
-		parachains_runtimes_test_utils::test_cases::can_governance_authorize_upgrade::<
-			Runtime,
-			RuntimeOrigin,
-		>(GovernanceOrigin::Location(Location::new(1, Parachain(COLLECTIVES_ID)))),
-		Either::Right(InstructionError { index: 0, error: XcmError::Barrier })
-	);
-	// no - Collectives Voice of Fellows plurality
-	assert_err!(
-		parachains_runtimes_test_utils::test_cases::can_governance_authorize_upgrade::<
-			Runtime,
-			RuntimeOrigin,
-		>(GovernanceOrigin::LocationAndDescendOrigin(
-			Location::new(1, Parachain(COLLECTIVES_ID)),
-			Plurality { id: BodyId::Technical, part: BodyPart::Voice }.into()
-		)),
-		Either::Right(InstructionError { index: 2, error: XcmError::BadOrigin })
-	);
-
-	// ok - relaychain
-	assert_ok!(parachains_runtimes_test_utils::test_cases::can_governance_authorize_upgrade::<
-		Runtime,
-		RuntimeOrigin,
-	>(GovernanceOrigin::Location(Location::parent())));
-	assert_ok!(parachains_runtimes_test_utils::test_cases::can_governance_authorize_upgrade::<
-		Runtime,
-		RuntimeOrigin,
-	>(GovernanceOrigin::Location(GovernanceLocation::get())));
 }

--- a/system-parachains/bridge-hub-paseo/src/xcm_config.rs
+++ b/system-parachains/bridge-hub-paseo/src/xcm_config.rs
@@ -41,7 +41,7 @@ use polkadot_parachain_primitives::primitives::Sibling;
 use sp_runtime::traits::AccountIdConversion;
 pub use system_parachains_constants::paseo::locations::GovernanceLocation;
 use system_parachains_constants::{
-	paseo::locations::{AssetHubLocation, AssetHubPlurality, EthereumNetwork},
+	paseo::locations::{AssetHubLocation, AssetHubPlurality, EthereumNetwork, RelayChainLocation},
 	TREASURY_PALLET_ID,
 };
 use xcm::latest::prelude::*;
@@ -125,9 +125,9 @@ pub type XcmOriginToTransactDispatchOrigin = (
 	// Native converter for sibling Parachains; will convert to a `SiblingPara` origin when
 	// recognized.
 	SiblingParachainAsNative<cumulus_pallet_xcm::Origin, RuntimeOrigin>,
-	// Superuser converter for the AssetHub location. This will allow it to issue a
+	// Superuser converter for the AssetHub and Relaychain locations. This will allow it to issue a
 	// transaction from the Root origin.
-	LocationAsSuperuser<Equals<AssetHubLocation>, RuntimeOrigin>,
+	LocationAsSuperuser<(Equals<AssetHubLocation>, Equals<RelayChainLocation>), RuntimeOrigin>,
 	// Native signed account converter; this just converts an `AccountId32` origin into a normal
 	// `RuntimeOrigin::Signed` origin of the same 32-byte value.
 	SignedAccountId32AsNative<RelayNetwork, RuntimeOrigin>,

--- a/system-parachains/bridge-hub-paseo/src/xcm_config.rs
+++ b/system-parachains/bridge-hub-paseo/src/xcm_config.rs
@@ -41,7 +41,7 @@ use polkadot_parachain_primitives::primitives::Sibling;
 use sp_runtime::traits::AccountIdConversion;
 pub use system_parachains_constants::paseo::locations::GovernanceLocation;
 use system_parachains_constants::{
-	paseo::locations::{AssetHubLocation, EthereumNetwork},
+	paseo::locations::{AssetHubLocation, AssetHubPlurality, EthereumNetwork},
 	TREASURY_PALLET_ID,
 };
 use xcm::latest::prelude::*;
@@ -50,11 +50,12 @@ use xcm_builder::{
 	AllowHrmpNotificationsFromRelayChain, AllowKnownQueryResponses, AllowSubscriptionsFrom,
 	AllowTopLevelPaidExecutionFrom, DenyRecursively, DenyReserveTransferToRelayChain, DenyThenTry,
 	DescribeAllTerminal, DescribeFamily, EnsureXcmOrigin, ExternalConsensusLocationsConverterFor,
-	FrameTransactionalProcessor, FungibleAdapter, HashedDescription, IsConcrete, ParentAsSuperuser,
-	ParentIsPreset, RelayChainAsNative, SendXcmFeeToAccount, SiblingParachainAsNative,
-	SiblingParachainConvertsVia, SignedAccountId32AsNative, SignedToAccountId32,
-	SovereignSignedViaLocation, TakeWeightCredit, TrailingSetTopicAsId, UsingComponents,
-	WeightInfoBounds, WithComputedOrigin, WithUniqueTopic, XcmFeeManagerFromComponents,
+	FrameTransactionalProcessor, FungibleAdapter, HashedDescription, IsConcrete,
+	LocationAsSuperuser, ParentIsPreset, RelayChainAsNative, SendXcmFeeToAccount,
+	SiblingParachainAsNative, SiblingParachainConvertsVia, SignedAccountId32AsNative,
+	SignedToAccountId32, SovereignSignedViaLocation, TakeWeightCredit, TrailingSetTopicAsId,
+	UsingComponents, WeightInfoBounds, WithComputedOrigin, WithUniqueTopic,
+	XcmFeeManagerFromComponents,
 };
 use xcm_executor::{traits::ConvertLocation, XcmExecutor};
 
@@ -124,9 +125,9 @@ pub type XcmOriginToTransactDispatchOrigin = (
 	// Native converter for sibling Parachains; will convert to a `SiblingPara` origin when
 	// recognized.
 	SiblingParachainAsNative<cumulus_pallet_xcm::Origin, RuntimeOrigin>,
-	// Superuser converter for the Relay-chain (Parent) location. This will allow it to issue a
+	// Superuser converter for the AssetHub location. This will allow it to issue a
 	// transaction from the Root origin.
-	ParentAsSuperuser<RuntimeOrigin>,
+	LocationAsSuperuser<Equals<AssetHubLocation>, RuntimeOrigin>,
 	// Native signed account converter; this just converts an `AccountId32` origin into a normal
 	// `RuntimeOrigin::Signed` origin of the same 32-byte value.
 	SignedAccountId32AsNative<RelayNetwork, RuntimeOrigin>,
@@ -183,6 +184,7 @@ pub type Barrier = TrailingSetTopicAsId<
 					AllowExplicitUnpaidExecutionFrom<(
 						ParentOrParentsPlurality,
 						FellowsPlurality,
+						AssetHubPlurality,
 						Equals<RelayTreasuryLocation>,
 						Equals<AssetHubLocation>,
 						Equals<SnowbridgeFrontendLocation>,

--- a/system-parachains/bridge-hub-paseo/tests/tests.rs
+++ b/system-parachains/bridge-hub-paseo/tests/tests.rs
@@ -692,14 +692,6 @@ fn governance_authorize_upgrade_works() {
 		>(GovernanceOrigin::Location(Location::new(1, Parachain(12334)))),
 		Either::Right(InstructionError { index: 0, error: XcmError::Barrier })
 	);
-	// no - Relay
-	assert_err!(
-		parachains_runtimes_test_utils::test_cases::can_governance_authorize_upgrade::<
-			Runtime,
-			RuntimeOrigin,
-		>(GovernanceOrigin::Location(Location::parent())),
-		Either::Right(InstructionError { index: 1, error: XcmError::BadOrigin })
-	);
 	// no - Collectives
 	assert_err!(
 		parachains_runtimes_test_utils::test_cases::can_governance_authorize_upgrade::<
@@ -729,4 +721,9 @@ fn governance_authorize_upgrade_works() {
 		Runtime,
 		RuntimeOrigin,
 	>(GovernanceOrigin::Location(GovernanceLocation::get())));
+	// ok - relay
+	assert_ok!(parachains_runtimes_test_utils::test_cases::can_governance_authorize_upgrade::<
+		Runtime,
+		RuntimeOrigin,
+	>(GovernanceOrigin::Location(Location::parent())));
 }

--- a/system-parachains/bridge-hub-paseo/tests/tests.rs
+++ b/system-parachains/bridge-hub-paseo/tests/tests.rs
@@ -692,12 +692,12 @@ fn governance_authorize_upgrade_works() {
 		>(GovernanceOrigin::Location(Location::new(1, Parachain(12334)))),
 		Either::Right(InstructionError { index: 0, error: XcmError::Barrier })
 	);
-	// no - AssetHub
+	// no - Relay
 	assert_err!(
 		parachains_runtimes_test_utils::test_cases::can_governance_authorize_upgrade::<
 			Runtime,
 			RuntimeOrigin,
-		>(GovernanceOrigin::Location(Location::new(1, Parachain(ASSET_HUB_ID)))),
+		>(GovernanceOrigin::Location(Location::parent())),
 		Either::Right(InstructionError { index: 1, error: XcmError::BadOrigin })
 	);
 	// no - Collectives
@@ -720,11 +720,11 @@ fn governance_authorize_upgrade_works() {
 		Either::Right(InstructionError { index: 2, error: XcmError::BadOrigin })
 	);
 
-	// ok - relaychain
+	// ok - AssetHub
 	assert_ok!(parachains_runtimes_test_utils::test_cases::can_governance_authorize_upgrade::<
 		Runtime,
 		RuntimeOrigin,
-	>(GovernanceOrigin::Location(Location::parent())));
+	>(GovernanceOrigin::Location(Location::new(1, Parachain(ASSET_HUB_ID)))));
 	assert_ok!(parachains_runtimes_test_utils::test_cases::can_governance_authorize_upgrade::<
 		Runtime,
 		RuntimeOrigin,

--- a/system-parachains/collectives-paseo/src/xcm_config.rs
+++ b/system-parachains/collectives-paseo/src/xcm_config.rs
@@ -36,7 +36,7 @@ use paseo_runtime_constants::xcm::body::FELLOWSHIP_ADMIN_INDEX;
 use polkadot_parachain_primitives::primitives::Sibling;
 use sp_runtime::traits::AccountIdConversion;
 use system_parachains_constants::{
-	paseo::locations::{AssetHubLocation, AssetHubPlurality},
+	paseo::locations::{AssetHubLocation, AssetHubPlurality, RelayChainLocation},
 	TREASURY_PALLET_ID,
 };
 use xcm::latest::prelude::*;
@@ -127,9 +127,9 @@ pub type XcmOriginToTransactDispatchOrigin = (
 	// Native converter for sibling Parachains; will convert to a `SiblingPara` origin when
 	// recognised.
 	SiblingParachainAsNative<cumulus_pallet_xcm::Origin, RuntimeOrigin>,
-	// Superuser converter for the AssetHub location. This will allow it to issue a
-	// transaction from the Root origin.
-	LocationAsSuperuser<Equals<AssetHubLocation>, RuntimeOrigin>,
+	// Superuser converter for the AssetHub and Relay chain locations. This will allow it to issue
+	// a transaction from the Root origin.
+	LocationAsSuperuser<(Equals<AssetHubLocation>, Equals<RelayChainLocation>), RuntimeOrigin>,
 	// Native signed account converter; this just converts an `AccountId32` origin into a normal
 	// `RuntimeOrigin::Signed` origin of the same 32-byte value.
 	SignedAccountId32AsNative<RelayNetwork, RuntimeOrigin>,

--- a/system-parachains/collectives-paseo/src/xcm_config.rs
+++ b/system-parachains/collectives-paseo/src/xcm_config.rs
@@ -35,7 +35,10 @@ use parachains_common::xcm_config::{
 use paseo_runtime_constants::xcm::body::FELLOWSHIP_ADMIN_INDEX;
 use polkadot_parachain_primitives::primitives::Sibling;
 use sp_runtime::traits::AccountIdConversion;
-use system_parachains_constants::{paseo::locations::AssetHubLocation, TREASURY_PALLET_ID};
+use system_parachains_constants::{
+	paseo::locations::{AssetHubLocation, AssetHubPlurality},
+	TREASURY_PALLET_ID,
+};
 use xcm::latest::prelude::*;
 use xcm_builder::{
 	AccountId32Aliases, AliasChildLocation, AliasOriginRootUsingFilter,
@@ -43,7 +46,7 @@ use xcm_builder::{
 	AllowTopLevelPaidExecutionFrom, DenyReserveTransferToRelayChain, DenyThenTry,
 	DescribeAllTerminal, DescribeFamily, DescribeTerminus, EnsureXcmOrigin,
 	FrameTransactionalProcessor, FungibleAdapter, HashedDescription, IsConcrete, LocatableAssetId,
-	OriginToPluralityVoice, ParentAsSuperuser, ParentIsPreset, RelayChainAsNative,
+	LocationAsSuperuser, OriginToPluralityVoice, ParentIsPreset, RelayChainAsNative,
 	SendXcmFeeToAccount, SiblingParachainAsNative, SiblingParachainConvertsVia,
 	SignedAccountId32AsNative, SignedToAccountId32, SovereignSignedViaLocation, TakeWeightCredit,
 	TrailingSetTopicAsId, UsingComponents, WeightInfoBounds, WithComputedOrigin, WithUniqueTopic,
@@ -124,9 +127,9 @@ pub type XcmOriginToTransactDispatchOrigin = (
 	// Native converter for sibling Parachains; will convert to a `SiblingPara` origin when
 	// recognised.
 	SiblingParachainAsNative<cumulus_pallet_xcm::Origin, RuntimeOrigin>,
-	// Superuser converter for the Relay-chain (Parent) location. This will allow it to issue a
+	// Superuser converter for the AssetHub location. This will allow it to issue a
 	// transaction from the Root origin.
-	ParentAsSuperuser<RuntimeOrigin>,
+	LocationAsSuperuser<Equals<AssetHubLocation>, RuntimeOrigin>,
 	// Native signed account converter; this just converts an `AccountId32` origin into a normal
 	// `RuntimeOrigin::Signed` origin of the same 32-byte value.
 	SignedAccountId32AsNative<RelayNetwork, RuntimeOrigin>,
@@ -173,7 +176,9 @@ pub type Barrier = TrailingSetTopicAsId<
 					// free execution.
 					AllowExplicitUnpaidExecutionFrom<(
 						ParentOrParentsPlurality,
+						AssetHubPlurality,
 						Equals<RelayTreasuryLocation>,
+						Equals<AssetHubLocation>,
 					)>,
 					// Subscriptions for version tracking are OK.
 					AllowSubscriptionsFrom<ParentRelayOrSiblingParachains>,

--- a/system-parachains/collectives-paseo/tests/tests.rs
+++ b/system-parachains/collectives-paseo/tests/tests.rs
@@ -16,14 +16,6 @@ fn governance_authorize_upgrade_works() {
 		>(GovernanceOrigin::Location(Location::new(1, Parachain(12334)))),
 		Either::Right(InstructionError { index: 0, error: XcmError::Barrier })
 	);
-	// no - Relay
-	assert_err!(
-		parachains_runtimes_test_utils::test_cases::can_governance_authorize_upgrade::<
-			Runtime,
-			RuntimeOrigin,
-		>(GovernanceOrigin::Location(Location::parent())),
-		Either::Right(InstructionError { index: 1, error: XcmError::BadOrigin })
-	);
 	// no - Collectives
 	assert_err!(
 		parachains_runtimes_test_utils::test_cases::can_governance_authorize_upgrade::<
@@ -53,4 +45,9 @@ fn governance_authorize_upgrade_works() {
 		Runtime,
 		RuntimeOrigin,
 	>(GovernanceOrigin::Location(GovernanceLocation::get())));
+	// ok - relay
+	assert_ok!(parachains_runtimes_test_utils::test_cases::can_governance_authorize_upgrade::<
+		Runtime,
+		RuntimeOrigin,
+	>(GovernanceOrigin::Location(Location::parent())));
 }

--- a/system-parachains/collectives-paseo/tests/tests.rs
+++ b/system-parachains/collectives-paseo/tests/tests.rs
@@ -16,13 +16,13 @@ fn governance_authorize_upgrade_works() {
 		>(GovernanceOrigin::Location(Location::new(1, Parachain(12334)))),
 		Either::Right(InstructionError { index: 0, error: XcmError::Barrier })
 	);
-	// no - AssetHub
+	// no - Relay
 	assert_err!(
 		parachains_runtimes_test_utils::test_cases::can_governance_authorize_upgrade::<
 			Runtime,
 			RuntimeOrigin,
-		>(GovernanceOrigin::Location(Location::new(1, Parachain(ASSET_HUB_ID)))),
-		Either::Right(InstructionError { index: 0, error: XcmError::Barrier })
+		>(GovernanceOrigin::Location(Location::parent())),
+		Either::Right(InstructionError { index: 1, error: XcmError::BadOrigin })
 	);
 	// no - Collectives
 	assert_err!(
@@ -44,11 +44,11 @@ fn governance_authorize_upgrade_works() {
 		Either::Right(InstructionError { index: 0, error: XcmError::Barrier })
 	);
 
-	// ok - relaychain
+	// ok - AssetHub
 	assert_ok!(parachains_runtimes_test_utils::test_cases::can_governance_authorize_upgrade::<
 		Runtime,
 		RuntimeOrigin,
-	>(GovernanceOrigin::Location(Location::parent())));
+	>(GovernanceOrigin::Location(Location::new(1, Parachain(ASSET_HUB_ID)))));
 	assert_ok!(parachains_runtimes_test_utils::test_cases::can_governance_authorize_upgrade::<
 		Runtime,
 		RuntimeOrigin,

--- a/system-parachains/constants/src/paseo.rs
+++ b/system-parachains/constants/src/paseo.rs
@@ -169,7 +169,7 @@ pub mod locations {
 	use xcm::latest::prelude::{Junction::*, Location, NetworkId};
 
 	parameter_types! {
-	pub RelayChainLocation: Location = Location::parent();
+		pub RelayChainLocation: Location = Location::parent();
 		pub AssetHubLocation: Location =
 			Location::new(1, Parachain(paseo_runtime_constants::system_parachain::ASSET_HUB_ID));
 		pub PeopleLocation: Location =

--- a/system-parachains/constants/src/paseo.rs
+++ b/system-parachains/constants/src/paseo.rs
@@ -169,6 +169,7 @@ pub mod locations {
 	use xcm::latest::prelude::{Junction::*, Location, NetworkId};
 
 	parameter_types! {
+	pub RelayChainLocation: Location = Location::parent();
 		pub AssetHubLocation: Location =
 			Location::new(1, Parachain(paseo_runtime_constants::system_parachain::ASSET_HUB_ID));
 		pub PeopleLocation: Location =

--- a/system-parachains/constants/src/paseo.rs
+++ b/system-parachains/constants/src/paseo.rs
@@ -174,7 +174,7 @@ pub mod locations {
 		pub PeopleLocation: Location =
 			Location::new(1, Parachain(paseo_runtime_constants::system_parachain::PEOPLE_ID));
 
-		pub GovernanceLocation: Location = Location::parent();
+		pub GovernanceLocation: Location = Location::new(1, Parachain(paseo_runtime_constants::system_parachain::ASSET_HUB_ID));
 
 		pub EthereumNetwork: NetworkId = NetworkId::Ethereum { chain_id: 11155111 };
 	}

--- a/system-parachains/constants/src/paseo.rs
+++ b/system-parachains/constants/src/paseo.rs
@@ -165,7 +165,7 @@ pub mod fee {
 }
 
 pub mod locations {
-	use frame_support::parameter_types;
+	use frame_support::{parameter_types, traits::Contains};
 	use xcm::latest::prelude::{Junction::*, Location, NetworkId};
 
 	parameter_types! {
@@ -177,5 +177,22 @@ pub mod locations {
 		pub GovernanceLocation: Location = Location::new(1, Parachain(paseo_runtime_constants::system_parachain::ASSET_HUB_ID));
 
 		pub EthereumNetwork: NetworkId = NetworkId::Ethereum { chain_id: 11155111 };
+	}
+
+	/// `Contains` implementation for the asset hub location pluralities.
+	pub struct AssetHubPlurality;
+	impl Contains<Location> for AssetHubPlurality {
+		fn contains(loc: &Location) -> bool {
+			matches!(
+				loc.unpack(),
+				(
+					1,
+					[
+						Parachain(paseo_runtime_constants::system_parachain::ASSET_HUB_ID),
+						Plurality { .. }
+					]
+				)
+			)
+		}
 	}
 }

--- a/system-parachains/coretime-paseo/src/tests.rs
+++ b/system-parachains/coretime-paseo/src/tests.rs
@@ -264,14 +264,6 @@ fn governance_authorize_upgrade_works() {
 		>(GovernanceOrigin::Location(Location::new(1, Parachain(12334)))),
 		Either::Right(InstructionError { index: 0, error: XcmError::Barrier })
 	);
-	// no - Relay
-	assert_err!(
-		parachains_runtimes_test_utils::test_cases::can_governance_authorize_upgrade::<
-			Runtime,
-			RuntimeOrigin,
-		>(GovernanceOrigin::Location(Location::parent())),
-		Either::Right(InstructionError { index: 1, error: XcmError::BadOrigin })
-	);
 	// no - Collectives
 	assert_err!(
 		parachains_runtimes_test_utils::test_cases::can_governance_authorize_upgrade::<
@@ -301,4 +293,10 @@ fn governance_authorize_upgrade_works() {
 		Runtime,
 		RuntimeOrigin,
 	>(GovernanceOrigin::Location(GovernanceLocation::get())));
+
+	// ok - RelayChain
+	assert_ok!(parachains_runtimes_test_utils::test_cases::can_governance_authorize_upgrade::<
+		Runtime,
+		RuntimeOrigin,
+	>(GovernanceOrigin::Location(Location::parent())));
 }

--- a/system-parachains/coretime-paseo/src/tests.rs
+++ b/system-parachains/coretime-paseo/src/tests.rs
@@ -264,13 +264,13 @@ fn governance_authorize_upgrade_works() {
 		>(GovernanceOrigin::Location(Location::new(1, Parachain(12334)))),
 		Either::Right(InstructionError { index: 0, error: XcmError::Barrier })
 	);
-	// no - AssetHub
+	// no - Relay
 	assert_err!(
 		parachains_runtimes_test_utils::test_cases::can_governance_authorize_upgrade::<
 			Runtime,
 			RuntimeOrigin,
-		>(GovernanceOrigin::Location(Location::new(1, Parachain(ASSET_HUB_ID)))),
-		Either::Right(InstructionError { index: 0, error: XcmError::Barrier })
+		>(GovernanceOrigin::Location(Location::parent())),
+		Either::Right(InstructionError { index: 1, error: XcmError::BadOrigin })
 	);
 	// no - Collectives
 	assert_err!(
@@ -292,11 +292,11 @@ fn governance_authorize_upgrade_works() {
 		Either::Right(InstructionError { index: 2, error: XcmError::BadOrigin })
 	);
 
-	// ok - relaychain
+	// ok - AssetHub
 	assert_ok!(parachains_runtimes_test_utils::test_cases::can_governance_authorize_upgrade::<
 		Runtime,
 		RuntimeOrigin,
-	>(GovernanceOrigin::Location(Location::parent())));
+	>(GovernanceOrigin::Location(Location::new(1, Parachain(ASSET_HUB_ID)))));
 	assert_ok!(parachains_runtimes_test_utils::test_cases::can_governance_authorize_upgrade::<
 		Runtime,
 		RuntimeOrigin,

--- a/system-parachains/coretime-paseo/src/xcm_config.rs
+++ b/system-parachains/coretime-paseo/src/xcm_config.rs
@@ -37,7 +37,7 @@ use paseo_runtime_constants::system_parachain;
 use polkadot_parachain_primitives::primitives::Sibling;
 use sp_runtime::traits::AccountIdConversion;
 use system_parachains_constants::{
-	paseo::locations::{AssetHubLocation, AssetHubPlurality},
+	paseo::locations::{AssetHubLocation, AssetHubPlurality, RelayChainLocation},
 	TREASURY_PALLET_ID,
 };
 use xcm::latest::prelude::*;
@@ -138,7 +138,7 @@ pub type XcmOriginToTransactDispatchOrigin = (
 	SiblingParachainAsNative<cumulus_pallet_xcm::Origin, RuntimeOrigin>,
 	// Superuser converter for the AssetHub location. This will allow it to issue a
 	// transaction from the Root origin.
-	LocationAsSuperuser<Equals<AssetHubLocation>, RuntimeOrigin>,
+	LocationAsSuperuser<(Equals<AssetHubLocation>, Equals<RelayChainLocation>), RuntimeOrigin>,
 	// Native signed account converter; this just converts an `AccountId32` origin into a normal
 	// `RuntimeOrigin::Signed` origin of the same 32-byte value.
 	SignedAccountId32AsNative<RelayNetwork, RuntimeOrigin>,

--- a/system-parachains/coretime-paseo/src/xcm_config.rs
+++ b/system-parachains/coretime-paseo/src/xcm_config.rs
@@ -136,7 +136,7 @@ pub type XcmOriginToTransactDispatchOrigin = (
 	// Native converter for sibling Parachains; will convert to a `SiblingPara` origin when
 	// recognized.
 	SiblingParachainAsNative<cumulus_pallet_xcm::Origin, RuntimeOrigin>,
-	// Superuser converter for the AssetHub location. This will allow it to issue a
+	// Superuser converter for the AssetHub and Relaychain locations. This will allow it to issue a
 	// transaction from the Root origin.
 	LocationAsSuperuser<(Equals<AssetHubLocation>, Equals<RelayChainLocation>), RuntimeOrigin>,
 	// Native signed account converter; this just converts an `AccountId32` origin into a normal

--- a/system-parachains/coretime-paseo/src/xcm_config.rs
+++ b/system-parachains/coretime-paseo/src/xcm_config.rs
@@ -36,7 +36,10 @@ use parachains_common::xcm_config::{
 use paseo_runtime_constants::system_parachain;
 use polkadot_parachain_primitives::primitives::Sibling;
 use sp_runtime::traits::AccountIdConversion;
-use system_parachains_constants::{paseo::locations::AssetHubLocation, TREASURY_PALLET_ID};
+use system_parachains_constants::{
+	paseo::locations::{AssetHubLocation, AssetHubPlurality},
+	TREASURY_PALLET_ID,
+};
 use xcm::latest::prelude::*;
 use xcm_builder::{
 	AccountId32Aliases, AliasChildLocation, AliasOriginRootUsingFilter,
@@ -44,10 +47,10 @@ use xcm_builder::{
 	AllowTopLevelPaidExecutionFrom, DenyReserveTransferToRelayChain, DenyThenTry,
 	DescribeAllTerminal, DescribeFamily, DescribeTerminus, EnsureXcmOrigin,
 	FrameTransactionalProcessor, FungibleAdapter, HashedDescription, IsConcrete,
-	NonFungibleAdapter, ParentAsSuperuser, ParentIsPreset, RelayChainAsNative, SendXcmFeeToAccount,
-	SiblingParachainAsNative, SiblingParachainConvertsVia, SignedAccountId32AsNative,
-	SignedToAccountId32, SovereignSignedViaLocation, TakeWeightCredit, TrailingSetTopicAsId,
-	UsingComponents, WeightInfoBounds, WithComputedOrigin, WithUniqueTopic,
+	LocationAsSuperuser, NonFungibleAdapter, ParentIsPreset, RelayChainAsNative,
+	SendXcmFeeToAccount, SiblingParachainAsNative, SiblingParachainConvertsVia,
+	SignedAccountId32AsNative, SignedToAccountId32, SovereignSignedViaLocation, TakeWeightCredit,
+	TrailingSetTopicAsId, UsingComponents, WeightInfoBounds, WithComputedOrigin, WithUniqueTopic,
 	XcmFeeManagerFromComponents,
 };
 use xcm_executor::{traits::ConvertLocation, XcmExecutor};
@@ -133,9 +136,9 @@ pub type XcmOriginToTransactDispatchOrigin = (
 	// Native converter for sibling Parachains; will convert to a `SiblingPara` origin when
 	// recognized.
 	SiblingParachainAsNative<cumulus_pallet_xcm::Origin, RuntimeOrigin>,
-	// Superuser converter for the Relay-chain (Parent) location. This will allow it to issue a
+	// Superuser converter for the AssetHub location. This will allow it to issue a
 	// transaction from the Root origin.
-	ParentAsSuperuser<RuntimeOrigin>,
+	LocationAsSuperuser<Equals<AssetHubLocation>, RuntimeOrigin>,
 	// Native signed account converter; this just converts an `AccountId32` origin into a normal
 	// `RuntimeOrigin::Signed` origin of the same 32-byte value.
 	SignedAccountId32AsNative<RelayNetwork, RuntimeOrigin>,
@@ -182,9 +185,11 @@ pub type Barrier = TrailingSetTopicAsId<
 					AllowTopLevelPaidExecutionFrom<Everything>,
 					// Parent and its pluralities (i.e. governance bodies) get free execution.
 					AllowExplicitUnpaidExecutionFrom<(
+						AssetHubPlurality,
 						ParentOrParentsPlurality,
 						FellowsPlurality,
 						Equals<RelayTreasuryLocation>,
+						Equals<AssetHubLocation>,
 					)>,
 					// Subscriptions for version tracking are OK.
 					AllowSubscriptionsFrom<ParentRelayOrSiblingParachains>,

--- a/system-parachains/people-paseo/src/tests.rs
+++ b/system-parachains/people-paseo/src/tests.rs
@@ -152,13 +152,13 @@ fn governance_authorize_upgrade_works() {
 		>(GovernanceOrigin::Location(Location::new(1, Parachain(12334)))),
 		Either::Right(InstructionError { index: 0, error: XcmError::Barrier })
 	);
-	// no - AssetHub
+	// no -Relay
 	assert_err!(
 		parachains_runtimes_test_utils::test_cases::can_governance_authorize_upgrade::<
 			Runtime,
 			RuntimeOrigin,
-		>(GovernanceOrigin::Location(Location::new(1, Parachain(ASSET_HUB_ID)))),
-		Either::Right(InstructionError { index: 0, error: XcmError::Barrier })
+		>(GovernanceOrigin::Location(Location::parent())),
+		Either::Right(InstructionError { index: 1, error: XcmError::BadOrigin })
 	);
 	// no - Collectives
 	assert_err!(
@@ -180,11 +180,11 @@ fn governance_authorize_upgrade_works() {
 		Either::Right(InstructionError { index: 2, error: XcmError::BadOrigin })
 	);
 
-	// ok - relaychain
+	// ok - AssetHub
 	assert_ok!(parachains_runtimes_test_utils::test_cases::can_governance_authorize_upgrade::<
 		Runtime,
 		RuntimeOrigin,
-	>(GovernanceOrigin::Location(Location::parent())));
+	>(GovernanceOrigin::Location(Location::new(1, Parachain(ASSET_HUB_ID)))));
 	assert_ok!(parachains_runtimes_test_utils::test_cases::can_governance_authorize_upgrade::<
 		Runtime,
 		RuntimeOrigin,

--- a/system-parachains/people-paseo/src/tests.rs
+++ b/system-parachains/people-paseo/src/tests.rs
@@ -152,14 +152,6 @@ fn governance_authorize_upgrade_works() {
 		>(GovernanceOrigin::Location(Location::new(1, Parachain(12334)))),
 		Either::Right(InstructionError { index: 0, error: XcmError::Barrier })
 	);
-	// no -Relay
-	assert_err!(
-		parachains_runtimes_test_utils::test_cases::can_governance_authorize_upgrade::<
-			Runtime,
-			RuntimeOrigin,
-		>(GovernanceOrigin::Location(Location::parent())),
-		Either::Right(InstructionError { index: 1, error: XcmError::BadOrigin })
-	);
 	// no - Collectives
 	assert_err!(
 		parachains_runtimes_test_utils::test_cases::can_governance_authorize_upgrade::<
@@ -189,4 +181,9 @@ fn governance_authorize_upgrade_works() {
 		Runtime,
 		RuntimeOrigin,
 	>(GovernanceOrigin::Location(GovernanceLocation::get())));
+	// ok - relay
+	assert_ok!(parachains_runtimes_test_utils::test_cases::can_governance_authorize_upgrade::<
+		Runtime,
+		RuntimeOrigin,
+	>(GovernanceOrigin::Location(Location::parent())));
 }

--- a/system-parachains/people-paseo/src/xcm_config.rs
+++ b/system-parachains/people-paseo/src/xcm_config.rs
@@ -38,18 +38,19 @@ use parachains_common::{
 use paseo_runtime_constants::system_parachain;
 use polkadot_parachain_primitives::primitives::Sibling;
 use sp_runtime::traits::AccountIdConversion;
-use system_parachains_constants::paseo::locations::AssetHubLocation;
+use system_parachains_constants::paseo::locations::{AssetHubLocation, AssetHubPlurality};
 use xcm::latest::prelude::*;
 use xcm_builder::{
 	AccountId32Aliases, AliasChildLocation, AliasOriginRootUsingFilter,
 	AllowExplicitUnpaidExecutionFrom, AllowKnownQueryResponses, AllowSubscriptionsFrom,
 	AllowTopLevelPaidExecutionFrom, DenyReserveTransferToRelayChain, DenyThenTry,
 	DescribeAllTerminal, DescribeFamily, DescribeTerminus, EnsureXcmOrigin,
-	FrameTransactionalProcessor, FungibleAdapter, HashedDescription, IsConcrete, ParentAsSuperuser,
-	ParentIsPreset, RelayChainAsNative, SendXcmFeeToAccount, SiblingParachainAsNative,
-	SiblingParachainConvertsVia, SignedAccountId32AsNative, SignedToAccountId32,
-	SovereignSignedViaLocation, TakeWeightCredit, TrailingSetTopicAsId, UsingComponents,
-	WeightInfoBounds, WithComputedOrigin, WithUniqueTopic, XcmFeeManagerFromComponents,
+	FrameTransactionalProcessor, FungibleAdapter, HashedDescription, IsConcrete,
+	LocationAsSuperuser, ParentIsPreset, RelayChainAsNative, SendXcmFeeToAccount,
+	SiblingParachainAsNative, SiblingParachainConvertsVia, SignedAccountId32AsNative,
+	SignedToAccountId32, SovereignSignedViaLocation, TakeWeightCredit, TrailingSetTopicAsId,
+	UsingComponents, WeightInfoBounds, WithComputedOrigin, WithUniqueTopic,
+	XcmFeeManagerFromComponents,
 };
 use xcm_executor::{traits::ConvertLocation, XcmExecutor};
 
@@ -138,9 +139,9 @@ pub type XcmOriginToTransactDispatchOrigin = (
 	// Native converter for sibling Parachains; will convert to a `SiblingPara` origin when
 	// recognized.
 	SiblingParachainAsNative<cumulus_pallet_xcm::Origin, RuntimeOrigin>,
-	// Superuser converter for the Relay-chain (Parent) location. This will allow it to issue a
+	// Superuser converter for the AssetHub location. This will allow it to issue a
 	// transaction from the Root origin.
-	ParentAsSuperuser<RuntimeOrigin>,
+	LocationAsSuperuser<Equals<AssetHubLocation>, RuntimeOrigin>,
 	// Native signed account converter; this just converts an `AccountId32` origin into a normal
 	// `RuntimeOrigin::Signed` origin of the same 32-byte value.
 	SignedAccountId32AsNative<RelayNetwork, RuntimeOrigin>,
@@ -194,9 +195,11 @@ pub type Barrier = TrailingSetTopicAsId<
 					AllowTopLevelPaidExecutionFrom<Everything>,
 					// Parent and its pluralities (i.e. governance bodies) get free execution.
 					AllowExplicitUnpaidExecutionFrom<(
+						AssetHubPlurality,
 						ParentOrParentsPlurality,
 						FellowsPlurality,
 						Equals<RelayTreasuryLocation>,
+						Equals<AssetHubLocation>,
 					)>,
 					// Subscriptions for version tracking are OK.
 					AllowSubscriptionsFrom<ParentRelayOrSiblingParachains>,

--- a/system-parachains/people-paseo/src/xcm_config.rs
+++ b/system-parachains/people-paseo/src/xcm_config.rs
@@ -38,7 +38,9 @@ use parachains_common::{
 use paseo_runtime_constants::system_parachain;
 use polkadot_parachain_primitives::primitives::Sibling;
 use sp_runtime::traits::AccountIdConversion;
-use system_parachains_constants::paseo::locations::{AssetHubLocation, AssetHubPlurality};
+use system_parachains_constants::paseo::locations::{
+	AssetHubLocation, AssetHubPlurality, RelayChainLocation,
+};
 use xcm::latest::prelude::*;
 use xcm_builder::{
 	AccountId32Aliases, AliasChildLocation, AliasOriginRootUsingFilter,
@@ -139,9 +141,9 @@ pub type XcmOriginToTransactDispatchOrigin = (
 	// Native converter for sibling Parachains; will convert to a `SiblingPara` origin when
 	// recognized.
 	SiblingParachainAsNative<cumulus_pallet_xcm::Origin, RuntimeOrigin>,
-	// Superuser converter for the AssetHub location. This will allow it to issue a
+	// Superuser converter for the AssetHub and Relaychain locations. This will allow it to issue a
 	// transaction from the Root origin.
-	LocationAsSuperuser<Equals<AssetHubLocation>, RuntimeOrigin>,
+	LocationAsSuperuser<(Equals<AssetHubLocation>, Equals<RelayChainLocation>), RuntimeOrigin>,
 	// Native signed account converter; this just converts an `AccountId32` origin into a normal
 	// `RuntimeOrigin::Signed` origin of the same 32-byte value.
 	SignedAccountId32AsNative<RelayNetwork, RuntimeOrigin>,


### PR DESCRIPTION
This PR updates release 1.7.1 to account for the AHM migration that already took place on Paseo in the systems chain code.

Mainly, all the system chains recognize AH as their authority now. Paseo itself and AssetHub are excluded from this PR as there'll be a dedicated PR for them

<!-- ClickUpRef: 869ah7at5 -->
:link: [zboto Link](https://app.clickup.com/t/869ah7at5)