### PR TITLE
chore: Improve create release workflow

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -157,11 +157,6 @@ jobs:
           fetch-depth: 0  # Fetch all history and tags
           fetch-tags: true  # Explicitly fetch all tags
 
-      - name: Rust cache
-        uses: Swatinem/rust-cache@v2.7.3
-        with:
-          cache-on-failure: true
-
       - name: Cache runtime target dir
         if: steps.check_package.outputs.should_run == 'true'
         uses: actions/cache@v3


### PR DESCRIPTION
Closes: 
- #286 
- #281 

This PR integrates the PAPI check runtime in our workflow and removes the chain spec generator from the release workflow, as this process is being moved to somewhere else. That way we can also create releases from the main branch which will be quicker as we'll be able to cache compilations :)

<!-- ClickUpRef: 869awpnnr -->
:link: [zboto Link](https://app.clickup.com/t/869awpnnr)