### PR TITLE
chore: reduce coretime price

### DIFF
--- a/system-parachains/coretime-paseo/src/coretime.rs
+++ b/system-parachains/coretime-paseo/src/coretime.rs
@@ -322,7 +322,7 @@ parameter_types! {
 	pub const BrokerPalletId: PalletId = PalletId(*b"py/broke");
 	pub const MinimumCreditPurchase: Balance = UNITS / 10;
 	pub const MinimumEndPrice: Balance = 500 * UNITS;
-	pub const FixedTargetPrice: Balance = 5000 * UNITS;
+	pub const FixedTargetPrice: Balance = 750 * UNITS;
 }
 
 pub struct SovereignAccountOf;


### PR DESCRIPTION
Reduces the coretime price even more.

By setting the target price to: `750` units, the sale will start at a price of `7500` (10x the target). And go down from that value all the way to the minimum end price of `500`.

As per https://docs.rs/pallet-broker/0.22.0/pallet_broker/struct.CenterTargetPrice.html

<!-- ClickUpRef: 869b1eawc -->
:link: [zboto Link](https://app.clickup.com/t/869b1eawc)