### PR TITLE
fix: wrong token in metadata

### DIFF
--- a/system-parachains/collectives-paseo/build.rs
+++ b/system-parachains/collectives-paseo/build.rs
@@ -21,7 +21,7 @@ fn main() {
 #[cfg(all(feature = "std", feature = "metadata-hash"))]
 fn main() {
 	substrate_wasm_builder::WasmBuilder::init_with_defaults()
-		.enable_metadata_hash("DOT", 10)
+		.enable_metadata_hash("PAS", 10)
 		.build()
 }
 

--- a/system-parachains/coretime-paseo/build.rs
+++ b/system-parachains/coretime-paseo/build.rs
@@ -22,7 +22,7 @@ fn main() {
 #[cfg(all(feature = "std", feature = "metadata-hash"))]
 fn main() {
 	substrate_wasm_builder::WasmBuilder::init_with_defaults()
-		.enable_metadata_hash("DOT", 10)
+		.enable_metadata_hash("PAS", 10)
 		.build()
 }
 

--- a/system-parachains/people-paseo/build.rs
+++ b/system-parachains/people-paseo/build.rs
@@ -21,7 +21,7 @@ fn main() {
 #[cfg(all(feature = "std", feature = "metadata-hash"))]
 fn main() {
 	substrate_wasm_builder::WasmBuilder::init_with_defaults()
-		.enable_metadata_hash("DOT", 10)
+		.enable_metadata_hash("PAS", 10)
 		.build()
 }
 


### PR DESCRIPTION
Fixes the token name in the metadata. Causing a metadata mismatch which prevented the proper usage of these chains from HWs.
It seems we have been running with this annoying bug for a while.


Thanks to @carlosala and @josepot for bringing attention and identifying this.

<!-- ClickUpRef: 869b314yc -->
:link: [zboto Link](https://app.clickup.com/t/869b314yc)