### PR TITLE
Add `RestrictOrigin` transaction extension

### DIFF
--- a/system-parachains/people-paseo/src/lib.rs
+++ b/system-parachains/people-paseo/src/lib.rs
@@ -113,6 +113,7 @@ pub type TxExtension = (
 	frame_system::CheckEra<Runtime>,
 	frame_system::CheckNonce<Runtime>,
 	frame_system::CheckWeight<Runtime>,
+	indiv_pallet_origin_restriction::RestrictOrigin<Runtime>,
 	pallet_asset_tx_payment::ChargeAssetTxPayment<Runtime>,
 	frame_metadata_hash_extension::CheckMetadataHash<Runtime>,
 );


### PR DESCRIPTION
This extension was missing, it is ok for our current experiment, but we might want to fix it at some point.

<!-- ClickUpRef: 869b59p9p -->
:link: [zboto Link](https://app.clickup.com/t/869b59p9p)