### PR TITLE
fix: Reduce local chain specs sizes

### DIFF
--- a/scripts/generate_chain_specs.sh
+++ b/scripts/generate_chain_specs.sh
@@ -101,7 +101,7 @@ for pkg in "${PACKAGES[@]}"; do
   get_package_params "$pkg"
 
   ARGS=(
-    --profile debug
+    --profile release
     --skip-build
     --raw
     --name "$NAME"

--- a/system-parachains/asset-hub-paseo/src/genesis_config_presets.rs
+++ b/system-parachains/asset-hub-paseo/src/genesis_config_presets.rs
@@ -82,7 +82,7 @@ fn asset_hub_paseo_genesis(
 		},
 	"staking": {
 		"validatorCount": 100,
-		"devStakers": Some((2_000,25_000))
+		"devStakers": Some((5,50))
 	},
 		"foreignAssets": ForeignAssetsConfig {
 			assets: foreign_assets


### PR DESCRIPTION
This PR aims to reduce the size of the local chain specs generated on release by:

- Switching the profile used to compute them to `release`. This was set to `debug` before sub0 to ensure chains running the generated specs show logs, but upon further investigation it's not really needed. Originally we thought `release` compilations deleted logging because there's not logs on production, but this is actually [happening here](https://github.com/paseo-network/runtimes/blob/main/system-parachains/asset-hub-paseo/Cargo.toml#L416), the `log` crate [doesn't behave differently without extra flags](https://github.com/rust-lang/log/blob/0.4.22/src/lib.rs#L1528). So we're okey on `release`, which considerably reduces sizes.

- Closing #295 -> After the AHM, `pallet-staking-async` was introduced to Paseo AssetHub and we set the `devStakers` genesis config to an unnecessarily big number. If we check the pallet genesis [build function](https://github.com/paritytech/polkadot-sdk/blob/master/substrate/frame/staking-async/src/pallet/mod.rs#L1013) we see this config will create state across multiple pallets for that number of validators/nominators (funding accounts, nominating, blablabla), which for our current set up leads into that 75MB monster size. This PR also reduces those numbers to a more reasonable value for local specs, leading to a 5MB file (of which 4.9MB is the runtime code), so we're ok

<!-- ClickUpRef: 869b6vxu9 -->
:link: [zboto Link](https://app.clickup.com/t/869b6vxu9)