### PR TITLE
Allow 12 blocks per relay parent

### DIFF
--- a/system-parachains/asset-hub-paseo/src/lib.rs
+++ b/system-parachains/asset-hub-paseo/src/lib.rs
@@ -144,8 +144,9 @@ use system_parachains_constants::{
 	},
 	paseo::{
 		consensus::{
-			elastic_scaling::{RELAY_PARENT_OFFSET, UNINCLUDED_SEGMENT_CAPACITY},
-			elastic_scaling_500ms::BLOCK_PROCESSING_VELOCITY,
+			elastic_scaling_500ms::{
+				BLOCK_PROCESSING_VELOCITY, RELAY_PARENT_OFFSET, UNINCLUDED_SEGMENT_CAPACITY,
+			},
 			RELAY_CHAIN_SLOT_DURATION_MILLIS,
 		},
 		currency::*,

--- a/system-parachains/constants/src/paseo.rs
+++ b/system-parachains/constants/src/paseo.rs
@@ -60,7 +60,7 @@ pub mod consensus {
 
 	/// Parameters enabling elastic scaling functionality.
 	pub mod elastic_scaling {
-		/// Build with an offset of 1 behind the relay chain.
+		/// Build with an offset behind the relay chain.
 		pub const RELAY_PARENT_OFFSET: u32 = 2;
 
 		/// The upper limit of how many parachain blocks are processed by the relay chain per
@@ -76,11 +76,19 @@ pub mod consensus {
 	}
 
 	pub mod elastic_scaling_500ms {
+		/// Build with an offset behind the relay chain.
+		pub const RELAY_PARENT_OFFSET: u32 = 2;
+
 		/// The upper limit of how many parachain blocks are processed by the relay chain per
 		/// parent. Limits the number of blocks authored per slot. This determines the minimum
 		/// block time of the parachain:
 		/// `RELAY_CHAIN_SLOT_DURATION_MILLIS/BLOCK_PROCESSING_VELOCITY`
 		pub const BLOCK_PROCESSING_VELOCITY: u32 = 12;
+
+		/// Maximum number of blocks simultaneously accepted by the Runtime, not yet included
+		/// into the relay chain.
+		pub const UNINCLUDED_SEGMENT_CAPACITY: u32 =
+			(3 + RELAY_PARENT_OFFSET) * BLOCK_PROCESSING_VELOCITY;
 	}
 }
 


### PR DESCRIPTION
If we want to have 500ms blocks, we need to allow 12 parachain blocks per relay parent.

<!-- ClickUpRef: 869byd5u7 -->
:link: [zboto Link](https://app.clickup.com/t/869byd5u7)