### PR TITLE
Add hyperbridge to parachains header root

### DIFF
--- a/relay/paseo/src/lib.rs
+++ b/relay/paseo/src/lib.rs
@@ -414,18 +414,25 @@ parameter_types! {
 	pub LeafVersion: MmrLeafVersion = MmrLeafVersion::new(0, 0);
 }
 
+/// Parathreads whitelisted to be added to the beefy mmr leaf parachains header root
+const BEEFY_WHITELISTED_PARATHREADS: &[ParaId] = &[
+	// Hyperbridge
+	ParaId::new(4009),
+];
+
 /// A BEEFY data provider that merkelizes all the parachain heads at the current block
 /// (sorted by their parachain id).
 pub struct ParaHeadsRootProvider;
 impl BeefyDataProvider<H256> for ParaHeadsRootProvider {
 	fn extra_data() -> H256 {
-		let mut para_heads: Vec<(u32, Vec<u8>)> = parachains_paras::Parachains::<Runtime>::get()
-			.into_iter()
+		let para_heads: BTreeMap<u32, Vec<u8>> = parachains_paras::Parachains::<Runtime>::get()
+			.iter()
+			.chain(BEEFY_WHITELISTED_PARATHREADS.iter())
 			.filter_map(|id| {
-				parachains_paras::Heads::<Runtime>::get(id).map(|head| (id.into(), head.0))
+				parachains_paras::Heads::<Runtime>::get(id).map(|head| ((*id).into(), head.0))
 			})
 			.collect();
-		para_heads.sort_by_key(|k| k.0);
+
 		binary_merkle_tree::merkle_root::<mmr::Hashing, _>(
 			para_heads.into_iter().map(|pair| pair.encode()),
 		)


### PR DESCRIPTION
## Summary

Port of [polkadot-fellows/runtimes#1073](https://github.com/polkadot-fellows/runtimes/pull/1073). Adds Hyperbridge (ParaId 4009) to the BEEFY MMR leaf parachains header root whitelist so its consensus client on connected networks can continue to be updated.

This is harmless even if Hyperbridge is still a parachain on Paseo — the `BTreeMap` collect deduplicates by key, so it will appear only once in the merkle root regardless.

<!-- ClickUpRef: 869c5xrct -->
:link: [zboto Link](https://app.clickup.com/t/869c5xrct)