### PR TITLE
Lower MaxEthExtrinsicWeight from 90% to 50%

### DIFF
--- a/system-parachains/asset-hub-paseo/src/lib.rs
+++ b/system-parachains/asset-hub-paseo/src/lib.rs
@@ -1149,7 +1149,7 @@ parameter_types! {
 	pub const DepositPerChildTrieItem: Balance = system_para_deposit(1, 0) / 10;
 	pub const DepositPerByte: Balance = system_para_deposit(0, 1);
 	pub CodeHashLockupDepositPercent: Perbill = Perbill::from_percent(30);
-	pub const MaxEthExtrinsicWeight: FixedU128 = FixedU128::from_rational(9, 10);
+	pub const MaxEthExtrinsicWeight: FixedU128 = FixedU128::from_rational(5, 10);
 }
 
 impl pallet_revive::Config for Runtime {


### PR DESCRIPTION
Reduce `pallet_revive::Config::MaxEthExtrinsicWeight` from 90% to 50% of block weight on Asset Hub Paseo. 

see https://github.com/polkadot-fellows/runtimes/pull/1091