### PR TITLE
Fix asset-hub-paseo build errors for staking rc-client v0.7.3

### DIFF
--- a/system-parachains/asset-hub-paseo/src/lib.rs
+++ b/system-parachains/asset-hub-paseo/src/lib.rs
@@ -183,6 +183,7 @@ use polkadot_runtime_common::{
 use weights::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight};
 
 impl_opaque_keys! {
+	#[derive(MaxEncodedLen)]
 	pub struct SessionKeys {
 		pub aura: Aura,
 	}

--- a/system-parachains/asset-hub-paseo/src/staking/mod.rs
+++ b/system-parachains/asset-hub-paseo/src/staking/mod.rs
@@ -508,13 +508,13 @@ sp_runtime::impl_opaque_keys! {
 
 parameter_types! {
 	// Deposit for one NextKeys entry and multiple KeyOwner entries and ExternallySetKeys.
-	pub KeyDeposit: Balance = polkadot_runtime_constants::currency::deposit(1, SessionKeys::max_encoded_len() as u32)
+	pub KeyDeposit: Balance = paseo_runtime_constants::currency::deposit(1, SessionKeys::max_encoded_len() as u32)
 		.saturating_add(
-			polkadot_runtime_constants::currency::deposit(<Runtime as pallet_session::Config>::Keys::key_ids().len() as u32,
+			paseo_runtime_constants::currency::deposit(<Runtime as pallet_session::Config>::Keys::key_ids().len() as u32,
 								<Runtime as pallet_session::Config>::ValidatorId::max_encoded_len() as u32
 			)
 		).saturating_add(
-			polkadot_runtime_constants::currency::deposit(1, AccountId::max_encoded_len() as u32)
+			paseo_runtime_constants::currency::deposit(1, AccountId::max_encoded_len() as u32)
 		);
 }
 
@@ -525,6 +525,7 @@ impl pallet_staking_async_rc_client::Config for Runtime {
 	type MaxValidatorSetRetries = ConstU32<64>;
 	type ValidatorSetExportSession = ValidatorSetExportSession;
 	type RelayChainSessionKeys = RelayChainSessionKeys;
+	type Currency = Balances;
 	// Need a smaller value since the benchmarks do not properly fund the account.
 	#[cfg(not(feature = "runtime-benchmarks"))]
 	type KeyDeposit = KeyDeposit;


### PR DESCRIPTION
## Summary

The `Create Runtimes Release` CI workflow [fails](https://github.com/paseo-network/runtimes/actions/runs/23428649667/job/68149296529) when building `asset-hub-paseo-runtime` due to three compilation errors introduced by the upgrade to `pallet-staking-async-rc-client` v0.7.3. This PR fixes all three:

- **`#[derive(MaxEncodedLen)]` on `SessionKeys`** — The `KeyDeposit` parameter calls `SessionKeys::max_encoded_len()`, but `impl_opaque_keys!` does not derive `MaxEncodedLen` by default. Adding the derive attribute resolves.

- **Replace `polkadot_runtime_constants` with `paseo_runtime_constants`** — The staking module referenced `polkadot_runtime_constants::currency::deposit()`, but that crate was never added as a dependency. `paseo_runtime_constants` is already available in the workspace and provides the same `deposit()` function.

- **Add `type Currency = Balances` to `pallet_staking_async_rc_client::Config`** — The `Currency` associated type was added in rc-client v0.7.3 (it was not required in v0.7.0).

All three fixes align with how the upstream [Polkadot Fellows runtimes](https://github.com/polkadot-fellows/runtimes) configure the same pallets for asset-hub-polkadot.

## Test plan

- [x] `cargo check -p asset-hub-paseo-runtime` passes locally
- [ ] CI `Create Runtimes Release` workflow passes