### PR TITLE
fix: Use on-chain fallback for multi-block election to prevent stuck eras

### DIFF
--- a/system-parachains/asset-hub-paseo/src/staking/mod.rs
+++ b/system-parachains/asset-hub-paseo/src/staking/mod.rs
@@ -149,22 +149,29 @@ impl pallet_dap::Config for Runtime {
 	type PalletId = DapPalletId;
 }
 
+/// Election bounds for the on-chain fallback solver.
+///
+/// In benchmarks these are unbounded; in production they are capped to a single snapshot page
+/// so that the on-chain solver stays within block weight limits.
 #[cfg(feature = "runtime-benchmarks")]
 parameter_types! {
-	pub BenchElectionBounds: frame_election_provider_support::bounds::ElectionBounds =
+	pub ElectionBoundsOnChain: frame_election_provider_support::bounds::ElectionBounds =
 		frame_election_provider_support::bounds::ElectionBoundsBuilder::default().build();
 }
+#[cfg(not(feature = "runtime-benchmarks"))]
+parameter_types! {
+	pub ElectionBoundsOnChain: frame_election_provider_support::bounds::ElectionBounds =
+		frame_election_provider_support::bounds::ElectionBoundsBuilder::default()
+			.voters_count(VoterSnapshotPerBlock::get().into())
+			.targets_count(MaxValidatorSet::get().into())
+			.build();
+}
 
-#[cfg(feature = "runtime-benchmarks")]
 pub struct OnChainConfig;
 
-#[cfg(feature = "runtime-benchmarks")]
 impl frame_election_provider_support::onchain::Config for OnChainConfig {
-	// unbounded
-	type Bounds = BenchElectionBounds;
-	// We should not need sorting, as our bounds are large enough for the number of
-	// nominators/validators in this test setup.
-	type Sort = ConstBool<false>;
+	type Bounds = ElectionBoundsOnChain;
+	type Sort = ConstBool<true>;
 	type DataProvider = Staking;
 	type MaxBackersPerWinner = MaxBackersPerWinner;
 	type MaxWinnersPerPage = MaxWinnersPerPage;
@@ -185,13 +192,13 @@ impl multi_block::Config for Runtime {
 	type DataProvider = Staking;
 	type MinerConfig = Self;
 	type Verifier = MultiBlockElectionVerifier;
-	// we chill and do nothing in the fallback.
-	#[cfg(not(feature = "runtime-benchmarks"))]
-	type Fallback = multi_block::Continue<Self>;
-	#[cfg(feature = "runtime-benchmarks")]
+	// Fall back to on-chain SequentialPhragmen if no signed/unsigned solution is submitted.
+	// This ensures era transitions always happen, even without external election miners.
 	type Fallback = frame_election_provider_support::onchain::OnChainExecution<OnChainConfig>;
-	// Revert back to signed phase if nothing is submitted and queued, so we prolong the election.
-	type AreWeDone = multi_block::RevertToSignedIfNotQueuedOf<Self>;
+	// Proceed to Done after one full election cycle regardless of whether a solution was queued.
+	// Combined with the on-chain Fallback above, this guarantees the election resolves and
+	// produces a (possibly suboptimal) validator set rather than looping indefinitely.
+	type AreWeDone = multi_block::ProceedRegardlessOf<Self>;
 	type OnRoundRotation = multi_block::CleanRound<Self>;
 	type WeightInfo = weights::pallet_election_provider_multi_block::WeightInfo<Runtime>;
 }


### PR DESCRIPTION
## Summary

The multi-block election on Asset Hub Paseo has been stuck in an infinite loop since ~March 10, preventing era transitions for 15+ days. Active era 2896 has not rotated because no election solution is being submitted.

### Root cause

The election provider was configured with:
- `Fallback = Continue` — a no-op that silently drops the election
- `AreWeDone = RevertToSignedIfNotQueuedOf` — loops back to the Signed phase if no solution is queued

Without external election miners (`polkadot-staking-miner`) or functioning OCW submitters, the election cycles indefinitely through Signed → SignedValidation → Unsigned → back to Signed, never producing a validator set. Without a validator set, the relay chain never activates a new set, and without an `activation_timestamp` in session reports, the era never transitions.

### Fix

- **`Fallback = OnChainExecution<OnChainConfig>`**: when no signed/unsigned solution is queued, fall back to the on-chain `SequentialPhragmen` solver to compute a valid (if suboptimal) validator set from the election snapshot
- **`AreWeDone = ProceedRegardlessOf`**: after one full election cycle, proceed to `Done` regardless of whether a solution was queued — this lets the fallback activate instead of looping forever

The on-chain fallback bounds are capped to a single snapshot page in production (704 voters, 1000 targets) to stay within block weight limits. In benchmarks, bounds remain unbounded as before.

### Why this is acceptable for Paseo

Paseo validators are public-permissioned. The on-chain fallback may produce the same or a suboptimal validator set compared to an externally computed solution, but the priority is ensuring **eras keep rotating**. Once `polkadot-staking-miner` instances are operational, they will submit optimal solutions during the Signed phase and the fallback will not activate.

### Chain state at time of diagnosis

| Item | Value |
|------|-------|
| Active era | 2896 (stuck since March 10) |
| Current (planned) era | 2897 |
| RC session index | 18,352 |
| Last validator set applied | Session 18,044 (308 sessions ago) |
| Election round | 678 (cycling) |
| Election phase | Signed (looping) |
| Signed submissions | 0 (none ever) |
| Snapshots | Present (7,923 voters, 152 targets) |

## Test plan

- [x] `cargo check -p asset-hub-paseo-runtime` compiles cleanly
- [ ] Verify on testnet that era transitions resume after runtime upgrade
- [ ] Confirm `polkadot-staking-miner` can still submit optimal solutions during Signed phase (fallback should not interfere)