### PR TITLE
remove foreign-assets-precompile

### DIFF
--- a/system-parachains/asset-hub-paseo/src/lib.rs
+++ b/system-parachains/asset-hub-paseo/src/lib.rs
@@ -134,7 +134,7 @@ use frame_system::{
 	limits::{BlockLength, BlockWeights},
 	EnsureRoot, EnsureSigned, EnsureSignedBy,
 };
-use pallet_assets_precompiles::{ForeignAssetId, ForeignIdConfig, InlineIdConfig, ERC20};
+use pallet_assets_precompiles::{InlineIdConfig, ERC20};
 use pallet_nfts::PalletFeatures;
 use pallet_nomination_pools::PoolId;
 use pallet_xcm_precompiles::XcmPrecompile;
@@ -412,13 +412,6 @@ parameter_types! {
 	pub const ForeignAssetsMetadataDepositPerByte: Balance = MetadataDepositPerByte::get();
 }
 
-impl pallet_assets_precompiles::ForeignAssetsConfig for Runtime {
-	// must match the AssetId type used by the `ForeignAssets` instance
-	type ForeignAssetId = <Runtime as pallet_assets::Config<ForeignAssetsInstance>>::AssetId;
-	#[cfg(feature = "runtime-benchmarks")]
-	type AssetsInstance = ForeignAssetsInstance;
-}
-
 /// Assets managed by some foreign location.
 ///
 /// Note: we do not declare a `ForeignAssetsCall` type, as this type is used in proxy definitions.
@@ -456,7 +449,7 @@ impl pallet_assets::Config<ForeignAssetsInstance> for Runtime {
 	type Holder = ();
 	type Extra = ();
 	type WeightInfo = weights::pallet_assets_foreign::WeightInfo<Runtime>;
-	type CallbackHandle = (ForeignAssetId<Runtime, ForeignAssetsInstance>,);
+	type CallbackHandle = ();
 	type AssetAccountDeposit = ForeignAssetsAssetAccountDeposit;
 	type RemoveItemsLimit = frame_support::traits::ConstU32<1000>;
 	type ReserveData = ForeignAssetReserveData;
@@ -1480,7 +1473,6 @@ impl pallet_revive::Config for Runtime {
 	type WeightInfo = pallet_revive::weights::SubstrateWeight<Self>;
 	type Precompiles = (
 		ERC20<Self, InlineIdConfig<0x120>, TrustBackedAssetsInstance>,
-		ERC20<Self, ForeignIdConfig<0x220, Self, ForeignAssetsInstance>, ForeignAssetsInstance>,
 		ERC20<Self, InlineIdConfig<0x320>, PoolAssetsInstance>,
 		XcmPrecompile<Self>,
 	);
@@ -1587,7 +1579,6 @@ construct_runtime!(
 
 		// Contracts
 		Revive: pallet_revive = 100,
-		AssetsPrecompiles: pallet_assets_precompiles::pallet = 101,
 
 		// Sudo.
 		Sudo: pallet_sudo::{Pallet, Call, Storage, Event<T>, Config<T>} = 251,

--- a/system-parachains/asset-hub-paseo/src/migrations.rs
+++ b/system-parachains/asset-hub-paseo/src/migrations.rs
@@ -46,17 +46,12 @@ mod multiblock_migrations {
 	use xcm_builder::StartsWith;
 
 	/// MBM migrations to apply on runtime upgrade.
-	pub type MbmMigrations = (
+	pub type MbmMigrations =
 		assets_common::migrations::foreign_assets_reserves::ForeignAssetsReservesMigration<
 			Runtime,
 			ForeignAssetsInstance,
 			AssetHubPaseoForeignAssetsReservesProvider,
-		>,
-		pallet_assets_precompiles::MigrateForeignAssetPrecompileMappings<
-			Runtime,
-			ForeignAssetsInstance,
-		>,
-	);
+		>;
 
 	/// This type provides reserves information for `asset_id`. Meant to be used in a migration
 	/// running on the Asset Hub Paseo upgrade which changes the Foreign Assets

--- a/system-parachains/asset-hub-paseo/src/xcm_config.rs
+++ b/system-parachains/asset-hub-paseo/src/xcm_config.rs
@@ -352,7 +352,6 @@ pub type Barrier = TrailingSetTopicAsId<
 							Equals<RelayTreasuryLocation>,
 							Equals<bridging::SiblingBridgeHub>,
 							AmbassadorEntities,
-							SecretaryEntities,
 							IsSiblingSystemParachain<ParaId, parachain_info::Pallet<Runtime>>,
 						),
 						TrustedAliasers,


### PR DESCRIPTION
This code needs `pallet-assets-precompile = 0.5.0` which will come with the release 2.2.0. But for 2.1.1 we cannot include it