### PR TITLE
hey team, comment trigger was sending invalid json for the zondax /bot dispatch

### DIFF
--- a/.github/workflows/comment-trigger.yml
+++ b/.github/workflows/comment-trigger.yml
@@ -35,7 +35,6 @@ jobs:
           if [[ "$comment" =~ ^/bot.* ]]; then
             echo "is_bot_command=true" >> $GITHUB_OUTPUT
             echo "command=$comment" >> $GITHUB_OUTPUT
-            echo $command
           else
             echo "is_bot_command=false" >> $GITHUB_OUTPUT
           fi
@@ -59,21 +58,34 @@ jobs:
         if: steps.check-comment.outputs.is_bot_command == 'true' && steps.check-team.outputs.is_allowed == 'true'
         env:
           GH_TOKEN: ${{ secrets.ZONDAX_CI_PAT }}
+          DISPATCH_CMD: ${{ steps.check-comment.outputs.command }}
+          DISPATCH_BRANCH: ${{ steps.pr-details.outputs.branch }}
         run: |
+          PAYLOAD=$(
+            jq -n \
+              --arg ref "main" \
+              --arg target_repo "https://github.com/${{ github.repository }}" \
+              --arg target_branch "$DISPATCH_BRANCH" \
+              --arg pr_number "${{ github.event.issue.number }}" \
+              --arg command "$DISPATCH_CMD" \
+              '{
+                ref: $ref,
+                inputs: {
+                  target_repo: $target_repo,
+                  target_branch: $target_branch,
+                  pr_number: $pr_number,
+                  command: $command
+                }
+              }'
+          )
           response=$(curl -L \
             -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer $GH_TOKEN" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/repos/Zondax/paseo-runtime-test/actions/workflows/bot-trigger.yml/dispatches \
-            -d '{
-              "ref": "main",
-              "inputs": {
-                "target_repo": "https://github.com/${{ github.repository }}",
-                "target_branch": "${{ steps.pr-details.outputs.branch }}",
-                "pr_number": "${{ github.event.issue.number }}",
-                "command": "${{ steps.check-comment.outputs.command }}"
-            }' -w "%{http_code}" -o /dev/null)
+            "https://api.github.com/repos/Zondax/paseo-runtime-test/actions/workflows/bot-trigger.yml/dispatches" \
+            -d "$PAYLOAD" \
+            -w "%{http_code}" -o /dev/null)
           if [ "$response" != "204" ]; then
             echo "Failed to trigger remote test. HTTP status code: $response"
             exit 1


### PR DESCRIPTION
hey paseo team, checked the comment trigger workflow and found the github workflow_dispatches request body was not valid json: there was a single `}` at the end so the outer object from the opening `{` on the `-d` line was never closed. the repositories dispatch api typically answers with 400 for that, so the zondax remote test job likely never started from `/bot`... comments.

fix: build the body with `jq` so the shape is always valid, and pass the pr comment with `--arg` plus env vars so shell quoting and double quotes in the text do not corrupt the request.

while here removed the `echo` that referenced a never-set `command` var (it was not the output name, so the line was a no-op for debugging).

cheers
