### PR TITLE
port: extra tx extensions on AH (fellows #1156)

### DIFF
--- a/system-parachains/asset-hub-paseo/src/lib.rs
+++ b/system-parachains/asset-hub-paseo/src/lib.rs
@@ -1590,6 +1590,7 @@ pub type TxExtension = cumulus_pallet_weight_reclaim::StorageWeightReclaim<
 		frame_system::CheckNonce<Runtime>,
 		frame_system::CheckWeight<Runtime>,
 		pallet_asset_conversion_tx_payment::ChargeAssetTxPayment<Runtime>,
+		pallet_claims::PrevalidateAttests<Runtime>,
 		frame_metadata_hash_extension::CheckMetadataHash<Runtime>,
 		pallet_revive::evm::tx_extension::SetOrigin<Runtime>,
 	),
@@ -1614,6 +1615,7 @@ impl pallet_revive::evm::runtime::EthExtra for EthExtraImpl {
 			frame_system::CheckNonce::<Runtime>::from(nonce),
 			frame_system::CheckWeight::<Runtime>::new(),
 			pallet_asset_conversion_tx_payment::ChargeAssetTxPayment::<Runtime>::from(tip, None),
+			pallet_claims::PrevalidateAttests::<Runtime>::new(),
 			frame_metadata_hash_extension::CheckMetadataHash::<Runtime>::new(false),
 			pallet_revive::evm::tx_extension::SetOrigin::<Runtime>::new_from_eth_transaction(),
 		)


### PR DESCRIPTION
Ports [polkadot-fellows/runtimes#1156](https://github.com/polkadot-fellows/runtimes/pull/1156) into Paseo.

## What

Adds `pallet_claims::PrevalidateAttests` to the Asset Hub `TxExtension` tuple and to the `EthExtra` implementation, mirroring the fellowship change.

## Notes

No naming adaptation was needed since the added lines are frame/pallet identifiers only. `pallet_claims` is already configured on Paseo AH (`Claims: pallet_claims = 15`), so `PrevalidateAttests` resolves.
