### PR TITLE
fix(asset-hub): restore precompile pallets in construct_runtime

### DIFF
--- a/system-parachains/asset-hub-paseo/src/lib.rs
+++ b/system-parachains/asset-hub-paseo/src/lib.rs
@@ -1560,6 +1560,8 @@ construct_runtime!(
 
 		// Contracts
 		Revive: pallet_revive = 100,
+		AssetsPrecompiles: pallet_assets_precompiles::pallet = 101,
+		AssetsPrecompilesPermit: pallet_assets_precompiles::permit::pallet = 102,
 
 		// Sudo.
 		Sudo: pallet_sudo::{Pallet, Call, Storage, Event<T>, Config<T>} = 251,


### PR DESCRIPTION
Restores the foreign-assets precompile pallets to `construct_runtime!` on Asset Hub.

## What

v2.2.2 (#366) re-added the foreign-assets precompile across the runtime (imports, the `pallet_revive` precompile entry, the `ForeignAssetsConfig` and `PermitConfig` impls, and the `define_benchmarks!` entry) but did not re-add the `construct_runtime!` pallet declarations that #364 had removed. The `AssetsPrecompiles` runtime instance therefore did not exist, and `cargo check --features runtime-benchmarks` failed with `E0412: cannot find type AssetsPrecompiles`. This should have been caught when releasing v2.2.2

This adds both pallets back, matching the fellowship runtime:

```
AssetsPrecompiles: pallet_assets_precompiles::pallet = 101,
AssetsPrecompilesPermit: pallet_assets_precompiles::permit::pallet = 102,
```

## Notes

All supporting code was already on `main`, so no new impls or migrations were needed. Verified that `cargo check` passes both with default features and with `--features runtime-benchmarks`.
