### PR TITLE
tighten monitoring and contributor docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# Agent Notes
+
+Use this file when working on the repo with coding agents.
+
+## Ground Rules
+
+- Treat the Rust runtime code, chain specs, and scripts as the source of truth.
+- Keep documentation short. Explain the intent, not every implementation detail.
+- Do not edit generated weights unless the task is explicitly about weights.
+- Do not rewrite unrelated files while making a focused runtime or tooling change.
+- Preserve existing formatting and naming unless there is a clear reason to change it.
+
+## Useful Checks
+
+- Run `cargo fmt` after Rust edits.
+- Run the smallest relevant test first. Broaden only when the change justifies it.
+- For docs-only changes, check links, commands, and file paths.
+
+## Monitoring Work
+
+- Keep monitoring thresholds tied to runtime constants where possible.
+- Document alert behavior from the operator's point of view.
+- Avoid duplicating exporter logic in prose. Point to the code when exact behavior matters.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Contributing
+
+This repository carries the Paseo runtime definitions and supporting tooling.
+Keep changes narrow and easy to review.
+
+## Before Opening A PR
+
+- State which runtime, chain spec, script, or monitoring component changed.
+- Include the command you ran to test the change.
+- Call out generated files such as weights or chain specs.
+- Keep prose updates concise and tied to files in the repo.
+
+## Runtime Changes
+
+- Prefer small commits that separate runtime logic, generated output, and docs.
+- Do not mix unrelated network changes in one PR.
+- When porting from Polkadot SDK, note the upstream version or commit.
+
+## Monitoring Changes
+
+- Explain the signal, threshold, and alert route.
+- Prefer runtime-derived thresholds over hardcoded timing assumptions.
+- Keep dashboards and alerts aligned with the same Prometheus series.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# Runtimes
+# Paseo Runtimes
 
-Runtimes for Polkadot's community testnet.
+Runtime definitions for the Paseo testnet. This repository contains the relay
+runtime, system parachain runtimes, chain specs, and helper scripts used to keep
+Paseo aligned with Polkadot SDK changes.
 
 ## Structure
 
@@ -15,11 +17,12 @@ Runtimes for Polkadot's community testnet.
     ├── people-paseo
     ├── coretime-paseo
 ```
----
 
 ## Testnet vs Production
 
-The following section presents the differences between testnet and production runtimes. By showing users the variations in available features and operational costs, users can better adjust their expectations when transitioning from testnet to production environments.
+Paseo tracks the production networks closely, but it is still a testnet. Treat
+the tables below as a quick check before carrying assumptions from Paseo to
+Kusama or Polkadot.
 
 ### Features
 
@@ -44,3 +47,9 @@ The following section presents the differences between testnet and production ru
 | Asset Creation | ~0.0017 + 0.4 Deposit | ~0.00012 + 0.013 Deposit | ~0.0018 + 0.4 Deposit |
 | Identity Creation | ~0.002 + 0.2 Deposit | ~0.00009 + 0.006 Deposit | ~0.002 + 0.2 Deposit |
 | Contract Instantiation (12K polkavm blob) | ~0.12 + 0.6 Deposit | ~0.004 + 0.02 Deposit | - |
+
+## Monitoring
+
+The relay block production monitoring design is documented in
+`paseo-relay-block-production-slo-design.md`. Keep monitoring docs tied to the
+exporter, Prometheus rules, and runtime constants they describe.

--- a/paseo-relay-block-production-slo-design.md
+++ b/paseo-relay-block-production-slo-design.md
@@ -1,0 +1,299 @@
+# Paseo Relay Block Production Monitoring
+
+Scope: relay block production for Paseo SLO #2. Finality is out of scope for
+this phase.
+
+Target SLO: 99.5% monthly relay availability. On a 30 day window, that leaves
+about 3 hours and 39 minutes of error budget.
+
+## Decisions
+
+- Build a small greenfield monitoring stack.
+- Use public relay RPC endpoints first.
+- Route alerts to Matrix only.
+- Add our own relay node scrape in a later phase.
+- Use the runtime's expected block time when deriving thresholds.
+
+## Vantage Points
+
+The exporter watches the public relay endpoints from `endpoints.json`.
+
+| Provider | Endpoint |
+| --- | --- |
+| dwellir | `wss://paseo-rpc.n.dwellir.com` |
+| dotters | `wss://paseo.dotters.network` |
+| ibp | `wss://paseo.ibp.network` |
+| amforc | `wss://paseo.rpc.amforc.com` |
+
+`dotters` and `ibp` may share infrastructure. Treat correlated failures there
+with care until we add our own relay node as an independent vantage point.
+
+## Primary Signal
+
+Track how long each endpoint has gone without a new best block:
+
+```text
+block_drift_seconds = now - local arrival time of the current best block
+```
+
+The exporter subscribes to `chain_subscribeNewHeads` for each endpoint and
+stamps the local arrival time of every head. Healthy drift should stay close to
+one or two expected block times. During a stall, drift increases once per wall
+clock second.
+
+This avoids height polling noise. It also works across runtime upgrades because
+the hot path only needs RPC headers.
+
+On startup, seed drift with `chain_getHeader` and the block timestamp inherent
+until the first subscribed head arrives.
+
+## Thresholds
+
+Do not hardcode 6 seconds. Read `api.consts.babe.expectedBlockTime` on connect
+and reread it after a `spec_version` change. Cross-check with
+`2 * api.consts.timestamp.minimumPeriod`.
+
+Current Paseo values:
+
+| Level | Formula | Current value |
+| --- | --- | --- |
+| Degraded | `5 * expected_block_time` | 30s |
+| P0 stall | `10 * expected_block_time` | 60s |
+
+BABE can skip slots under normal conditions, so the thresholds are expressed as
+skipped-slot tolerance instead of fixed seconds.
+
+## Quorum Rule
+
+Use the freshest healthy vantage point to decide whether the chain is producing:
+
+```promql
+paseo_relay:block_drift:min =
+  min(paseo_block_drift_seconds and on(provider) (paseo_rpc_up == 1))
+```
+
+A single lagging provider should not page. The chain is treated as stalled only
+when every healthy vantage point has stale block drift.
+
+Provider-level drift is still recorded for dashboards and provider health work.
+
+## Exporter
+
+`paseo-chain-exporter` bridges public RPC into Prometheus. Native node metrics
+already exist on nodes we operate, but public providers do not expose their
+`:9615` endpoints.
+
+Per public endpoint, the exporter should:
+
+- Open one WebSocket connection.
+- Subscribe to new best heads.
+- Subscribe to finalized heads for later finality work.
+- Mark `rpc_up=0` on disconnect, subscription stall, or timeout.
+- Poll `system_health` every 30 seconds.
+- Poll `state_getRuntimeVersion` and `system_version` every 60 seconds.
+- Reconnect with backoff.
+
+It exposes:
+
+- `GET /metrics` for Prometheus.
+- `GET /healthz` for a coarse producing or not-producing verdict.
+- `GET /status.json` for a cacheable public status payload.
+
+`/status.json` should be component-shaped from the start:
+
+```json
+{
+  "relay": {
+    "status": "up",
+    "drift": 8,
+    "providers": {}
+  }
+}
+```
+
+System chains can be added later without changing the public payload shape.
+
+## Metrics
+
+Labels: `provider`, `endpoint`, `chain="relay"`.
+
+| Metric | Type | Meaning |
+| --- | --- | --- |
+| `paseo_rpc_up` | gauge | Endpoint connection and subscription state |
+| `paseo_best_block` | gauge | Best block number |
+| `paseo_finalized_block` | gauge | Finalized block number |
+| `paseo_block_drift_seconds` | gauge | Seconds since the current best head arrived |
+| `paseo_finality_lag` | gauge | Best block minus finalized block |
+| `paseo_peers` | gauge | Peer count from `system_health` |
+| `paseo_is_syncing` | gauge | Sync state from `system_health` |
+| `paseo_spec_version` | gauge | Runtime spec version |
+| `paseo_expected_block_time_ms` | gauge | Runtime-declared expected block time |
+| `paseo_scrape_errors_total` | counter | RPC and subscription errors |
+| `paseo_exporter_build_info` | gauge | Exporter version and commit labels |
+
+## Recording Rules
+
+```promql
+paseo_relay:degraded_threshold:seconds =
+  5 * max(paseo_expected_block_time_ms) / 1000
+
+paseo_relay:stall_threshold:seconds =
+  10 * max(paseo_expected_block_time_ms) / 1000
+
+paseo_relay:producing:bool =
+  paseo_relay:block_drift:min <= bool scalar(paseo_relay:degraded_threshold:seconds)
+
+paseo_relay:producing:ratio_rate5m =
+  avg_over_time(paseo_relay:producing:bool[5m])
+
+paseo_relay:producing:ratio_rate30m =
+  avg_over_time(paseo_relay:producing:bool[30m])
+
+paseo_relay:producing:ratio_rate1h =
+  avg_over_time(paseo_relay:producing:bool[1h])
+
+paseo_relay:producing:ratio_rate6h =
+  avg_over_time(paseo_relay:producing:bool[6h])
+
+paseo_relay:producing:ratio_rate3d =
+  avg_over_time(paseo_relay:producing:bool[3d])
+
+paseo_relay:availability:ratio_30d =
+  avg_over_time(paseo_relay:producing:bool[30d])
+```
+
+Blindness is bad time. If all endpoints are down or the exporter is absent,
+availability must not score as healthy.
+
+## Alerts
+
+Hard liveness:
+
+```yaml
+- alert: RelayBlockProductionStalled
+  expr: paseo_relay:block_drift:min > scalar(paseo_relay:stall_threshold:seconds)
+  labels: { severity: page, slo: relay-availability }
+  annotations:
+    summary: "Relay block production stalled across all healthy vantage points"
+
+- alert: RelayBlockProductionDegraded
+  expr: paseo_relay:block_drift:min > scalar(paseo_relay:degraded_threshold:seconds)
+  for: 5m
+  labels: { severity: ticket, slo: relay-availability }
+```
+
+Burn rate:
+
+```yaml
+- alert: RelayProductionFastBurn
+  expr: |
+    (1 - paseo_relay:producing:ratio_rate1h) > (14.4 * 0.005)
+    and
+    (1 - paseo_relay:producing:ratio_rate5m) > (14.4 * 0.005)
+  labels: { severity: page, slo: relay-availability }
+
+- alert: RelayProductionSlowBurn
+  expr: |
+    (1 - paseo_relay:producing:ratio_rate6h) > (6 * 0.005)
+    and
+    (1 - paseo_relay:producing:ratio_rate30m) > (6 * 0.005)
+  labels: { severity: ticket, slo: relay-availability }
+
+- alert: RelayProductionBudgetBurn3d
+  expr: (1 - paseo_relay:producing:ratio_rate3d) > (1 * 0.005)
+  labels: { severity: ticket, slo: relay-availability }
+```
+
+Monitor-the-monitor:
+
+```yaml
+- alert: RelayMonitorBlind
+  expr: |
+    count(paseo_rpc_up == 1) == 0
+    or absent(paseo_block_drift_seconds)
+  for: 2m
+  labels: { severity: page, slo: relay-availability }
+  annotations:
+    summary: "Relay monitoring has no healthy vantage points"
+
+- alert: PaseoExporterDown
+  expr: up{job="paseo-chain-exporter"} == 0
+  for: 2m
+  labels: { severity: page }
+
+- alert: RelayExpectedBlockTimeChanged
+  expr: changes(max(paseo_expected_block_time_ms)[1h:]) > 0
+  labels: { severity: ticket, slo: relay-availability }
+  annotations:
+    summary: "babe.expectedBlockTime changed; confirm the runtime timing change"
+```
+
+Route `severity=page` to the P0 Matrix room and `severity=ticket` to the normal
+alerts room through an Alertmanager webhook bridge.
+
+## Dashboard Panels
+
+- Best and finalized height per provider.
+- Block drift per provider plus the quorum minimum.
+- Degraded and stall threshold lines.
+- Provider availability heatmap from `rpc_up`.
+- 30 day SLO availability and error budget.
+- Peer count, sync state, spec version, and expected block time.
+
+## Stack
+
+| Service | Role |
+| --- | --- |
+| `paseo-chain-exporter` | Public RPC prober and `/status.json` source |
+| `prometheus` | Scrape, recording rules, alert rules |
+| `alertmanager` | Routing, deduplication, silences |
+| `matrix-bridge` | Alertmanager webhook to Matrix |
+| `grafana` | Operator dashboards |
+
+Use a 15 second Prometheus scrape and evaluation interval. Keep 90 days of
+retention so the 30 day SLO has history.
+
+Run the stack outside the failure domain it monitors.
+
+## Phases
+
+Phase 0: public RPC relay block production monitoring.
+
+Build the exporter, Prometheus rules, Matrix alerts, Grafana dashboards, and
+the 30 day availability calculation.
+
+Phase 1: own relay node scrape.
+
+Scrape native `:9615` metrics from one or two r0gue relay full nodes. Use this
+as a corroborating vantage point. A local node falling behind must not page by
+itself.
+
+Phase 2: finality.
+
+Add finalized-head drift, GRANDPA metrics, and finality alerts. The exporter
+already records finalized height and finality lag.
+
+Phase 3: public status page.
+
+Expose status from `/status.json` or a static export of it. The public page
+must not query internal Prometheus directly.
+
+## Build Order
+
+1. Scaffold the compose stack with named Prometheus and Grafana volumes.
+2. Build `paseo-chain-exporter` with `prom-client` and RPC-only probes.
+3. Add `/metrics`, `/healthz`, and `/status.json`.
+4. Add Prometheus scrape config, recording rules, and alert rules.
+5. Configure Alertmanager and the Matrix bridge.
+6. Provision the Grafana datasource and dashboards.
+7. Inject provider drift past 30 seconds and 60 seconds to test ticket and page alerts.
+8. Kill the exporter and confirm blindness alerts fire.
+9. Deploy to the chosen host and watch a full day before treating the SLO as active.
+
+## Open Questions
+
+1. Where should the stack run?
+2. Which Matrix rooms and access token should Alertmanager use?
+3. Should Grafana stay internal while the public surface is only the status page?
+4. Is a 15 second scrape interval acceptable, or do we want 10 seconds?
+5. Which status page approach should we use once `/status.json` is stable?

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,14 +1,15 @@
 # Runtime Patch Scripts
 
-This directory contains scripts for managing runtime patches:
+These scripts move Paseo runtime changes between Polkadot SDK versions.
 
-1. `create_runtime_patch.sh`: Creates patch files with the new code from the Polkadot repo.
-2. `apply_runtime_patch.sh`: Applies patches.
-3. `revert_unwanted_changes.py`: Reverts specific changes in files.
+- `create_runtime_patch.sh`: Create patches from Polkadot runtime changes.
+- `apply_runtime_patch.sh`: Apply one patch file.
+- `revert_unwanted_changes.py`: Revert configured changes that should not land in Paseo.
 
-## Creating the runtime patch files
+## Create Runtime Patches
 
-Creates patch files for Paseo-specific modifications based on the differences between Polkadot runtime versions.
+Create patch files for Paseo-specific changes between two Polkadot runtime
+versions.
 
 Usage:
 
@@ -20,8 +21,8 @@ Parameters:
 
 - `current_version`: The current Paseo runtime version
 - `new_version`: The new Polkadot runtime version to update to
-- `--paseo-ref-branch`: Optional. Specify the branch to clone for Paseo runtime. Defaults to 'main'.
-- `--parachains`: Optional. Process parachains if specified.
+- `--paseo-ref-branch`: Branch to clone for the Paseo runtime. Defaults to `main`.
+- `--parachains`: Also process system parachains.
 
 Example:
 
@@ -33,13 +34,13 @@ Example:
 ./scripts/create_runtime_patch.sh 1.2.3 1.2.4 --parachains
 ```
 
-This script will create the following patch files in the `patches` directory:
+The script writes these files under `patches`:
 
-- `0001-Update-to-polkadot-relay-${NEXT_TAG}.patch`: Contains changes for the relay chain and Cargo.toml
-- `system-parachains/${parachain_name}/0001-update-to-${parachain_name}-${NEXT_TAG}.patch`: Created for each specified parachain if `--parachains` is set
-- `system-parachains/0001-update-to-parachains-${NEXT_TAG}.patch`: Contains changes for the `system-parachains/constants` directory and `system-parachains/Cargo.toml` file
+- `0001-Update-to-polkadot-relay-${NEXT_TAG}.patch`: Relay runtime and `Cargo.toml` changes.
+- `system-parachains/${parachain_name}/0001-update-to-${parachain_name}-${NEXT_TAG}.patch`: Per-parachain patch when `--parachains` is set.
+- `system-parachains/0001-update-to-parachains-${NEXT_TAG}.patch`: Shared system parachain constants and `Cargo.toml` changes.
 
-## Apply the patch
+## Apply a Patch
 
 Usage:
 
@@ -48,8 +49,9 @@ Usage:
 ```
 
 Parameters:
-- `--check`: Optional. Performs a dry run of the patch application process.
-- `<patch_file>`: Path to the patch file to be applied.
+
+- `--check`: Dry run. Validate the patch without changing files.
+- `<patch_file>`: Patch file to apply.
 
 Examples:
 
@@ -61,11 +63,12 @@ Examples:
 ./scripts/apply_runtime_patch.sh --check ../patches/relay_polkadot.patch
 ```
 
-This script will attempt to apply the specified patch file using Git's patch application functionality. If successful, it will unstage all changes, allowing you to review and commit them manually.
+After a successful apply, the script unstages the changes so they can be
+reviewed before commit.
 
-## Revert unwanted changes
+## Revert Unwanted Changes
 
-Reverts specific changes in files based on predefined rules.
+Revert configured changes that should not be carried into Paseo.
 
 Usage:
 
@@ -79,4 +82,5 @@ Example:
 python revert_unwanted_changes.py replacement_config.json
 ```
 
-The `revert_unwanted_changes.py` script logs its actions to `revert_unwanted_changes.log` in the current directory.
+The script writes its log to `revert_unwanted_changes.log` in the current
+directory.

--- a/system-parachains/asset-hub-paseo/src/lib.rs
+++ b/system-parachains/asset-hub-paseo/src/lib.rs
@@ -1560,6 +1560,8 @@ construct_runtime!(
 
 		// Contracts
 		Revive: pallet_revive = 100,
+		AssetsPrecompiles: pallet_assets_precompiles::pallet = 101,
+		AssetsPrecompilesPermit: pallet_assets_precompiles::permit::pallet = 102,
 
 		// Sudo.
 		Sudo: pallet_sudo::{Pallet, Call, Storage, Event<T>, Config<T>} = 251,


### PR DESCRIPTION
## Summary
- tighten the root README and runtime patch script README
- add concise agent and contributor guidance
- add a shorter relay block-production monitoring design note

## Impact
- documentation-only change
- keeps monitoring prose tied to exporter behavior, Prometheus rules, and runtime constants

## Validation
- git diff --cached --check
- git diff --check