### PR TITLE
feat: upgrade people-paseo to polkadot-fellows v2.3.0

### DIFF
--- a/system-parachains/people-paseo/src/lib.rs
+++ b/system-parachains/people-paseo/src/lib.rs
@@ -134,7 +134,10 @@ pub mod migrations {
 	use super::*;
 
 	/// Unreleased migrations. Add new ones here:
-	pub type Unreleased = (cumulus_pallet_xcmp_queue::migration::v6::MigrateV5ToV6<Runtime>,);
+	pub type Unreleased = (
+		cumulus_pallet_xcmp_queue::migration::v6::MigrateV5ToV6<Runtime>,
+		cumulus_pallet_parachain_system::migration::Migration<Runtime>,
+	);
 
 	/// Migrations/checks that do not need to be versioned and can run on every update.
 	pub type Permanent = pallet_xcm::migration::MigrateToLatestXcmVersion<Runtime>;
@@ -166,7 +169,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: Cow::Borrowed("people-paseo"),
 	impl_name: Cow::Borrowed("people-paseo"),
 	authoring_version: 1,
-	spec_version: 2_002_002,
+	spec_version: 2_003_000,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 0,
@@ -261,13 +264,13 @@ impl pallet_balances::Config for Runtime {
 	type RuntimeFreezeReason = RuntimeFreezeReason;
 	type RuntimeHoldReason = RuntimeHoldReason;
 	type FreezeIdentifier = ();
-	type MaxFreezes = ConstU32<0>;
+	type MaxFreezes = frame_support::traits::VariantCountOf<RuntimeFreezeReason>;
 	type DoneSlashHandler = ();
 }
 
 parameter_types! {
 	/// Relay Chain `TransactionByteFee` / 10.
-	pub const TransactionByteFee: Balance = MILLICENTS;
+	pub const TransactionByteFee: Balance = system_parachains_constants::paseo::fee::TRANSACTION_BYTE_FEE;
 }
 
 impl pallet_transaction_payment::Config for Runtime {


### PR DESCRIPTION
### Changes (`system-parachains/people-paseo/src/lib.rs`)
- Add `cumulus_pallet_parachain_system::migration::Migration` to `Unreleased`.
- `spec_version` `2_002_002` → `2_003_000`.
- `MaxFreezes`: `ConstU32<0>` → `VariantCountOf<RuntimeFreezeReason>`.
- `TransactionByteFee`: `MILLICENTS` → `system_parachains_constants::paseo::fee::TRANSACTION_BYTE_FEE` (accept upstream's named-constant change, using **Paseo's** module).

### Deliberately NOT applied: upstream's 24s Aura slot
Upstream `people-polkadot` v2.3.0 sets `SLOT_DURATION = 24_000` (24s, single-block). Paseo people uses **elastic scaling** (`BLOCK_PROCESSING_VELOCITY = 3`, ~2s blocks per `system-parachains/constants/src/paseo.rs`), which is incompatible with a 24s slot (consistency Pair D: `SLOT_DURATION == RELAY_CHAIN_SLOT_DURATION_MILLIS / BLOCK_PROCESSING_VELOCITY`). Reverted to preserve Paseo's elastic-scaling consensus.
