### PR TITLE
feat: upgrade coretime-paseo to polkadot-fellows v2.3.0

### DIFF
--- a/system-parachains/coretime-paseo/src/lib.rs
+++ b/system-parachains/coretime-paseo/src/lib.rs
@@ -139,6 +139,7 @@ pub mod migrations {
 		cumulus_pallet_aura_ext::migration::MigrateV0ToV1<Runtime>,
 		pallet_broker::migration::MigrateV3ToV4<Runtime, BrokerMigrationV4BlockConversion>,
 		cumulus_pallet_xcmp_queue::migration::v6::MigrateV5ToV6<Runtime>,
+		cumulus_pallet_parachain_system::migration::Migration<Runtime>,
 	);
 
 	/// Migrations/checks that do not need to be versioned and can run on every update.
@@ -166,7 +167,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: Cow::Borrowed("coretime-paseo"),
 	impl_name: Cow::Borrowed("coretime-paseo"),
 	authoring_version: 1,
-	spec_version: 2_002_002,
+	spec_version: 2_003_000,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 0,
@@ -288,7 +289,7 @@ impl pallet_timestamp::Config for Runtime {
 	/// A timestamp: milliseconds since the unix epoch.
 	type Moment = u64;
 	type OnTimestampSet = Aura;
-	type MinimumPeriod = ConstU64<{ SLOT_DURATION / 2 }>;
+	type MinimumPeriod = ConstU64<0>;
 	type WeightInfo = weights::pallet_timestamp::WeightInfo<Runtime>;
 }
 
@@ -314,13 +315,13 @@ impl pallet_balances::Config for Runtime {
 	type RuntimeHoldReason = RuntimeHoldReason;
 	type RuntimeFreezeReason = RuntimeFreezeReason;
 	type FreezeIdentifier = ();
-	type MaxFreezes = ConstU32<0>;
+	type MaxFreezes = frame_support::traits::VariantCountOf<RuntimeFreezeReason>;
 	type DoneSlashHandler = ();
 }
 
 parameter_types! {
 	/// Relay Chain `TransactionByteFee` / 10
-	pub const TransactionByteFee: Balance = MILLICENTS;
+	pub const TransactionByteFee: Balance = system_parachains_constants::paseo::fee::TRANSACTION_BYTE_FEE;
 }
 
 impl pallet_transaction_payment::Config for Runtime {
@@ -478,7 +479,7 @@ impl pallet_aura::Config for Runtime {
 	type AuthorityId = AuraId;
 	type DisabledValidators = ();
 	type MaxAuthorities = ConstU32<100_000>;
-	type AllowMultipleBlocksPerSlot = ConstBool<false>;
+	type AllowMultipleBlocksPerSlot = ConstBool<true>;
 	type SlotDuration = ConstU64<SLOT_DURATION>;
 }
 


### PR DESCRIPTION
### Changes (`system-parachains/coretime-paseo/src/lib.rs`)
- Add `cumulus_pallet_parachain_system::migration::Migration` to `Unreleased`.
- `spec_version` `2_002_002` → `2_003_000`.
- **Enable async backing** (upstream's "multiple blocks per slot for remaining system parachains"): `AllowMultipleBlocksPerSlot` `false`→`true`, `MinimumPeriod` `SLOT_DURATION/2`→`0`.
- `MaxFreezes`: `ConstU32<0>` → `VariantCountOf<RuntimeFreezeReason>`.
- `TransactionByteFee`: `MILLICENTS` → `system_parachains_constants::paseo::fee::TRANSACTION_BYTE_FEE`.
