### PR TITLE
feat: upgrade bridge-hub-paseo to polkadot-fellows v2.3.0

### DIFF
--- a/system-parachains/bridge-hub-paseo/src/lib.rs
+++ b/system-parachains/bridge-hub-paseo/src/lib.rs
@@ -40,7 +40,7 @@ use bridge_to_kusama_config::bp_kusama;
 use codec::{Decode, DecodeWithMemTracking, Encode, MaxEncodedLen};
 use cumulus_pallet_parachain_system::RelayNumberMonotonicallyIncreases;
 use cumulus_primitives_core::ParaId;
-use snowbridge_core::{AgentId, PricingParameters};
+use snowbridge_core::{sparse_bitmap::SparseBitmap, AgentId, PricingParameters};
 use snowbridge_outbound_queue_primitives::v1::{Command, Fee};
 
 use sp_api::impl_runtime_apis;
@@ -186,6 +186,7 @@ pub mod migrations {
 			bp_messages::LegacyLaneId,
 		>,
 		cumulus_pallet_xcmp_queue::migration::v6::MigrateV5ToV6<Runtime>,
+		cumulus_pallet_parachain_system::migration::Migration<Runtime>,
 	);
 
 	/// Migrations/checks that do not need to be versioned and can run on every update.
@@ -216,7 +217,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: Cow::Borrowed("bridge-hub-paseo"),
 	impl_name: Cow::Borrowed("bridge-hub-paseo"),
 	authoring_version: 1,
-	spec_version: 2_002_002,
+	spec_version: 2_003_000,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 4,
@@ -320,7 +321,7 @@ impl pallet_timestamp::Config for Runtime {
 	/// A timestamp: milliseconds since the unix epoch.
 	type Moment = u64;
 	type OnTimestampSet = Aura;
-	type MinimumPeriod = ConstU64<{ SLOT_DURATION / 2 }>;
+	type MinimumPeriod = ConstU64<0>;
 	type WeightInfo = weights::pallet_timestamp::WeightInfo<Runtime>;
 }
 
@@ -348,7 +349,7 @@ impl pallet_balances::Config for Runtime {
 	type RuntimeHoldReason = RuntimeHoldReason;
 	type RuntimeFreezeReason = RuntimeFreezeReason;
 	type FreezeIdentifier = ();
-	type MaxFreezes = ConstU32<0>;
+	type MaxFreezes = frame_support::traits::VariantCountOf<RuntimeFreezeReason>;
 	type DoneSlashHandler = ();
 }
 
@@ -524,7 +525,7 @@ impl pallet_aura::Config for Runtime {
 	type AuthorityId = AuraId;
 	type DisabledValidators = ();
 	type MaxAuthorities = ConstU32<100_000>;
-	type AllowMultipleBlocksPerSlot = ConstBool<false>;
+	type AllowMultipleBlocksPerSlot = ConstBool<true>;
 	type SlotDuration = ConstU64<SLOT_DURATION>;
 }
 
@@ -1030,15 +1031,18 @@ mod benches {
 		}
 
 		fn prepare_rewards_account(
+			_relayer: &AccountId,
 			reward_kind: Self::Reward,
-			reward: Balance,
-		) -> Option<
+			reward: Self::RewardBalance,
+		) -> Option<(
+			Self::Reward,
 			pallet_bridge_relayers::BeneficiaryOf<
 				Runtime,
 				bridge_common_config::BridgeRelayersInstance,
 			>,
-		> {
-			let bridge_common_config::BridgeReward::PolkadotKusamaBridge(reward_kind) = reward_kind
+		)> {
+			let bridge_common_config::BridgeReward::PolkadotKusamaBridge(inner_reward_kind) =
+				reward_kind
 			else {
 				panic!(
 					"Unexpected reward_kind: {reward_kind:?} - not compatible with `bench_reward`!"
@@ -1049,10 +1053,13 @@ mod benches {
 				AccountId,
 				bp_messages::LegacyLaneId,
 				Balance,
-			>::rewards_account(reward_kind);
+			>::rewards_account(inner_reward_kind);
 			Self::deposit_account(rewards_account.clone(), reward);
 
-			Some(bridge_common_config::BridgeRewardBeneficiaries::LocalAccount(rewards_account))
+			Some((
+				reward_kind,
+				bridge_common_config::BridgeRewardBeneficiaries::LocalAccount(rewards_account),
+			))
 		}
 
 		fn deposit_account(account: AccountId, balance: Balance) {
@@ -1136,7 +1143,7 @@ mod benches {
 			Weight,
 		) {
 			use cumulus_primitives_core::XcmpMessageSource;
-			assert!(XcmpQueue::take_outbound_messages(usize::MAX).is_empty());
+			assert!(XcmpQueue::take_outbound_messages(usize::MAX, &[]).is_empty());
 			ParachainSystem::open_outbound_hrmp_channel_for_benchmarks_or_tests(42.into());
 			PolkadotXcm::force_xcm_version(
 				RuntimeOrigin::root(),
@@ -1187,7 +1194,7 @@ mod benches {
 
 		fn is_message_successfully_dispatched(_nonce: bp_messages::MessageNonce) -> bool {
 			use cumulus_primitives_core::XcmpMessageSource;
-			!XcmpQueue::take_outbound_messages(usize::MAX).is_empty()
+			!XcmpQueue::take_outbound_messages(usize::MAX, &[]).is_empty()
 		}
 	}
 
@@ -1535,6 +1542,12 @@ impl_runtime_apis! {
 	impl snowbridge_outbound_queue_v2_runtime_api::OutboundQueueV2Api<Block, Balance> for Runtime {
 		fn prove_message(leaf_index: u64) -> Option<snowbridge_merkle_tree::MerkleProof> {
 			snowbridge_pallet_outbound_queue_v2::api::prove_message::<Runtime>(leaf_index)
+		}
+	}
+
+	impl snowbridge_pallet_inbound_queue_v2::InboundQueueV2Api<Block> for Runtime {
+		fn is_message_relayed(nonce: u64) -> bool {
+			snowbridge_pallet_inbound_queue_v2::Nonce::<Runtime>::get(nonce)
 		}
 	}
 

--- a/system-parachains/bridge-hub-paseo/tests/snowbridge.rs
+++ b/system-parachains/bridge-hub-paseo/tests/snowbridge.rs
@@ -179,7 +179,7 @@ impl Contains<Location> for MockWaivedLocations {
 
 struct MockFeeHandler;
 impl HandleFee for MockFeeHandler {
-	fn handle_fee(fee: Assets, _context: Option<&XcmContext>, _reason: FeeReason) -> Assets {
+	fn handle_fee(fee: xcm_executor::AssetsInHolding, _context: Option<&XcmContext>, _reason: FeeReason) -> xcm_executor::AssetsInHolding {
 		fee
 	}
 }
@@ -382,6 +382,7 @@ fn construct_extrinsic(
 ) -> UncheckedExtrinsic {
 	let account_id = AccountId32::from(sender.public());
 	let extra: TxExtension = (
+		frame_system::AuthorizeCall::<Runtime>::new(),
 		frame_system::CheckNonZeroSender::<Runtime>::new(),
 		frame_system::CheckSpecVersion::<Runtime>::new(),
 		frame_system::CheckTxVersion::<Runtime>::new(),

--- a/system-parachains/bridge-hub-paseo/tests/snowbridge.rs
+++ b/system-parachains/bridge-hub-paseo/tests/snowbridge.rs
@@ -179,7 +179,11 @@ impl Contains<Location> for MockWaivedLocations {
 
 struct MockFeeHandler;
 impl HandleFee for MockFeeHandler {
-	fn handle_fee(fee: xcm_executor::AssetsInHolding, _context: Option<&XcmContext>, _reason: FeeReason) -> xcm_executor::AssetsInHolding {
+	fn handle_fee(
+		fee: xcm_executor::AssetsInHolding,
+		_context: Option<&XcmContext>,
+		_reason: FeeReason,
+	) -> xcm_executor::AssetsInHolding {
 		fee
 	}
 }

--- a/system-parachains/bridge-hub-paseo/tests/tests.rs
+++ b/system-parachains/bridge-hub-paseo/tests/tests.rs
@@ -103,6 +103,7 @@ fn construct_extrinsic(
 ) -> UncheckedExtrinsic {
 	let account_id = AccountId32::from(sender.public());
 	let extra: TxExtension = (
+		frame_system::AuthorizeCall::<Runtime>::new(),
 		frame_system::CheckNonZeroSender::<Runtime>::new(),
 		frame_system::CheckSpecVersion::<Runtime>::new(),
 		frame_system::CheckTxVersion::<Runtime>::new(),
@@ -266,6 +267,7 @@ fn handle_export_message_from_system_parachain_add_to_outbound_queue_works() {
 			Runtime,
 			XcmConfig,
 			WithBridgeHubKusamaMessagesInstance,
+			LocationToAccountId,
 		>(
 			collator_session_keys(),
 			bp_bridge_hub_polkadot::BRIDGE_HUB_POLKADOT_PARACHAIN_ID,


### PR DESCRIPTION
### Changes (`system-parachains/bridge-hub-paseo/src/lib.rs`)
- **Enable async backing**: `AllowMultipleBlocksPerSlot` `false`→`true`, `MinimumPeriod` `SLOT_DURATION/2`→`0`.
- Add `cumulus_pallet_parachain_system::migration::Migration` to `Unreleased`.
- Expose **`snowbridge_pallet_inbound_queue_v2::InboundQueueV2Api`** (`is_message_relayed`).
- `snowbridge_core`: import `SparseBitmap`.
- Update benchmark helpers for the new SDK: `prepare_rewards_account` signature (relayer arg + tuple return) and `XcmpQueue::take_outbound_messages(.., &[])`.
- `MaxFreezes` → `VariantCountOf<RuntimeFreezeReason>`; `spec_version` `2_002_002`→`2_003_000`.