### PR TITLE
Add SafeSudo proxy type to all Paseo runtimes

### DIFF
--- a/relay/paseo/constants/src/lib.rs
+++ b/relay/paseo/constants/src/lib.rs
@@ -20,6 +20,66 @@ extern crate alloc;
 
 pub mod weights;
 
+/// Generates `call_can_change_sudo`, the recursive guard used by the `SafeSudo` proxy type.
+///
+/// `SafeSudo` behaves like `Any` but must never let a (possibly nested) call change or remove the
+/// sudo key. Each runtime has its own `RuntimeCall` type, so the matcher is emitted per runtime
+/// via this macro. Pass the runtime's call type and, for runtimes that have them, the extra
+/// pallets to block wholesale (`Scheduler`/`Preimage` can defer or hash-hide a call past this
+/// filter, so they cannot be allowed):
+///
+/// ```ignore
+/// paseo_runtime_constants::impl_call_can_change_sudo!(RuntimeCall, block = [Scheduler, Preimage]);
+/// paseo_runtime_constants::impl_call_can_change_sudo!(RuntimeCall);
+/// ```
+///
+/// The invoking runtime must have `pallet_sudo`, `pallet_utility`, `pallet_multisig`,
+/// `pallet_proxy` and `frame_system` in scope (every Paseo runtime does).
+///
+/// NOTE: when adding a pallet that can dispatch as `Root` or as the sudo account (new governance,
+/// new call wrappers, deferred dispatch), block it here or via `block = [..]` at the call site, or
+/// `SafeSudo` may leak a path to the key.
+#[macro_export]
+macro_rules! impl_call_can_change_sudo {
+	($rc:path $(, block = [ $( $extra:ident ),+ $(,)? ])?) => {
+		/// Returns `true` if `call` could (recursively) change or remove the sudo key, or mint an
+		/// escalation path to it. Used by the `SafeSudo` proxy filter.
+		fn call_can_change_sudo(call: &$rc) -> bool {
+			// The pallet aliases (`System`, `Proxy`, …) are type aliases, so importing the
+			// same-named call variants into the value namespace is unambiguous in patterns.
+			use $rc::{Multisig, Proxy, Sudo, System, Utility $( $(, $extra)+ )?};
+			match call {
+				// Directly change or remove the sudo key.
+				Sudo(pallet_sudo::Call::set_key { .. }) |
+				Sudo(pallet_sudo::Call::remove_key { .. }) => true,
+				// Raw storage surgery can overwrite or delete `Sudo::Key`.
+				System(frame_system::Call::set_storage { .. }) |
+				System(frame_system::Call::kill_storage { .. }) |
+				System(frame_system::Call::kill_prefix { .. }) => true,
+				// Proxy management could mint a more powerful proxy (an escalation path).
+				Proxy(..) => true,
+				// Extra pallets blocked wholesale (e.g. deferred / hash-hidden dispatch).
+				$( $( $extra(..) => true, )+ )?
+				// Single-call wrappers: recurse into the wrapped call.
+				Sudo(pallet_sudo::Call::sudo { call }) |
+				Sudo(pallet_sudo::Call::sudo_unchecked_weight { call, .. }) |
+				Sudo(pallet_sudo::Call::sudo_as { call, .. }) |
+				Utility(pallet_utility::Call::as_derivative { call, .. }) |
+				Utility(pallet_utility::Call::dispatch_as { call, .. }) |
+				Utility(pallet_utility::Call::with_weight { call, .. }) |
+				Multisig(pallet_multisig::Call::as_multi_threshold_1 { call, .. }) =>
+					call_can_change_sudo(call),
+				// Batches: recurse into every wrapped call.
+				Utility(pallet_utility::Call::batch { calls }) |
+				Utility(pallet_utility::Call::batch_all { calls }) |
+				Utility(pallet_utility::Call::force_batch { calls }) =>
+					calls.iter().any(call_can_change_sudo),
+				_ => false,
+			}
+		}
+	};
+}
+
 pub use self::currency::DOLLARS;
 
 /// Money matters.

--- a/relay/paseo/constants/src/lib.rs
+++ b/relay/paseo/constants/src/lib.rs
@@ -199,6 +199,14 @@ pub mod proxy {
 		/// Operator proxy for validators. Can only manage session keys. Cannot do staking
 		/// operations since they moved to Asset Hub.
 		StakingOperator = 10,
+		/// Sudo-capable proxy whose one restriction is that it can never change or remove the
+		/// sudo key. Intended for automations that need `sudo` access: if the proxy key leaks,
+		/// the sudo account itself stays recoverable. See the runtime's `call_can_change_sudo`
+		/// for the exact (recursive) set of forbidden calls.
+		///
+		/// The index is padded well above the contiguous range so upstream can keep appending
+		/// proxy types (11, 12, …) without colliding with this Paseo-specific variant.
+		SafeSudo = 100,
 	}
 
 	/// Remote proxy interface that uses the relay chain as remote location.

--- a/relay/paseo/src/lib.rs
+++ b/relay/paseo/src/lib.rs
@@ -1275,43 +1275,7 @@ impl InstanceFilter<RuntimeCall> for TransparentProxyType<ProxyType> {
 	}
 }
 
-/// Returns `true` if `call` could change or remove the sudo key, mint an escalation path to it,
-/// or defer/hide a call that later could (`Scheduler`/`Preimage`). The check is recursive so the
-/// forbidden leaf calls cannot be smuggled through `sudo`, `utility` batching, `dispatch_as`,
-/// etc. Used by the [`ProxyType::SafeSudo`] filter.
-///
-/// NOTE: when adding a pallet that can dispatch as `Root` or as the sudo account (new governance,
-/// new call wrappers, deferred dispatch), add it here or `SafeSudo` may leak a path to the key.
-fn call_can_change_sudo(call: &RuntimeCall) -> bool {
-	match call {
-		// Directly change or remove the sudo key.
-		RuntimeCall::Sudo(pallet_sudo::Call::set_key { .. }) |
-		RuntimeCall::Sudo(pallet_sudo::Call::remove_key { .. }) => true,
-		// Raw storage surgery can overwrite or delete `Sudo::Key`.
-		RuntimeCall::System(frame_system::Call::set_storage { .. }) |
-		RuntimeCall::System(frame_system::Call::kill_storage { .. }) |
-		RuntimeCall::System(frame_system::Call::kill_prefix { .. }) => true,
-		// Proxy management could mint a more powerful proxy (an escalation path to the key).
-		RuntimeCall::Proxy(..) => true,
-		// Deferred / hash-bounded dispatch escapes this filter at execution time; refuse it.
-		RuntimeCall::Scheduler(..) | RuntimeCall::Preimage(..) => true,
-		// Single-call wrappers: recurse into the wrapped call.
-		RuntimeCall::Sudo(pallet_sudo::Call::sudo { call }) |
-		RuntimeCall::Sudo(pallet_sudo::Call::sudo_unchecked_weight { call, .. }) |
-		RuntimeCall::Sudo(pallet_sudo::Call::sudo_as { call, .. }) |
-		RuntimeCall::Utility(pallet_utility::Call::as_derivative { call, .. }) |
-		RuntimeCall::Utility(pallet_utility::Call::dispatch_as { call, .. }) |
-		RuntimeCall::Utility(pallet_utility::Call::with_weight { call, .. }) |
-		RuntimeCall::Multisig(pallet_multisig::Call::as_multi_threshold_1 { call, .. }) =>
-			call_can_change_sudo(call),
-		// Batches: recurse into every wrapped call.
-		RuntimeCall::Utility(pallet_utility::Call::batch { calls }) |
-		RuntimeCall::Utility(pallet_utility::Call::batch_all { calls }) |
-		RuntimeCall::Utility(pallet_utility::Call::force_batch { calls }) =>
-			calls.iter().any(call_can_change_sudo),
-		_ => false,
-	}
-}
+paseo_runtime_constants::impl_call_can_change_sudo!(RuntimeCall, block = [Scheduler, Preimage]);
 
 impl pallet_proxy::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;

--- a/relay/paseo/src/lib.rs
+++ b/relay/paseo/src/lib.rs
@@ -1255,6 +1255,9 @@ impl InstanceFilter<RuntimeCall> for TransparentProxyType<ProxyType> {
 						RuntimeCall::Utility { .. }
 				)
 			},
+			// Behaves like `Any`, except it can never change or remove the sudo key (directly
+			// or via any nesting wrapper). See `call_can_change_sudo`.
+			ProxyType::SafeSudo => !call_can_change_sudo(c),
 		}
 	}
 
@@ -1263,10 +1266,50 @@ impl InstanceFilter<RuntimeCall> for TransparentProxyType<ProxyType> {
 			(x, y) if x == y => true,
 			(ProxyType::Any, _) => true,
 			(_, ProxyType::Any) => false,
+			// `SafeSudo` can drive sudo, which `NonTransfer` cannot, so it is not a subset of it.
+			(ProxyType::NonTransfer, ProxyType::SafeSudo) => false,
 			(ProxyType::NonTransfer, _) => true,
 			(ProxyType::Staking, ProxyType::StakingOperator) => true,
 			_ => false,
 		}
+	}
+}
+
+/// Returns `true` if `call` could change or remove the sudo key, mint an escalation path to it,
+/// or defer/hide a call that later could (`Scheduler`/`Preimage`). The check is recursive so the
+/// forbidden leaf calls cannot be smuggled through `sudo`, `utility` batching, `dispatch_as`,
+/// etc. Used by the [`ProxyType::SafeSudo`] filter.
+///
+/// NOTE: when adding a pallet that can dispatch as `Root` or as the sudo account (new governance,
+/// new call wrappers, deferred dispatch), add it here or `SafeSudo` may leak a path to the key.
+fn call_can_change_sudo(call: &RuntimeCall) -> bool {
+	match call {
+		// Directly change or remove the sudo key.
+		RuntimeCall::Sudo(pallet_sudo::Call::set_key { .. }) |
+		RuntimeCall::Sudo(pallet_sudo::Call::remove_key { .. }) => true,
+		// Raw storage surgery can overwrite or delete `Sudo::Key`.
+		RuntimeCall::System(frame_system::Call::set_storage { .. }) |
+		RuntimeCall::System(frame_system::Call::kill_storage { .. }) |
+		RuntimeCall::System(frame_system::Call::kill_prefix { .. }) => true,
+		// Proxy management could mint a more powerful proxy (an escalation path to the key).
+		RuntimeCall::Proxy(..) => true,
+		// Deferred / hash-bounded dispatch escapes this filter at execution time; refuse it.
+		RuntimeCall::Scheduler(..) | RuntimeCall::Preimage(..) => true,
+		// Single-call wrappers: recurse into the wrapped call.
+		RuntimeCall::Sudo(pallet_sudo::Call::sudo { call }) |
+		RuntimeCall::Sudo(pallet_sudo::Call::sudo_unchecked_weight { call, .. }) |
+		RuntimeCall::Sudo(pallet_sudo::Call::sudo_as { call, .. }) |
+		RuntimeCall::Utility(pallet_utility::Call::as_derivative { call, .. }) |
+		RuntimeCall::Utility(pallet_utility::Call::dispatch_as { call, .. }) |
+		RuntimeCall::Utility(pallet_utility::Call::with_weight { call, .. }) |
+		RuntimeCall::Multisig(pallet_multisig::Call::as_multi_threshold_1 { call, .. }) =>
+			call_can_change_sudo(call),
+		// Batches: recurse into every wrapped call.
+		RuntimeCall::Utility(pallet_utility::Call::batch { calls }) |
+		RuntimeCall::Utility(pallet_utility::Call::batch_all { calls }) |
+		RuntimeCall::Utility(pallet_utility::Call::force_batch { calls }) =>
+			calls.iter().any(call_can_change_sudo),
+		_ => false,
 	}
 }
 

--- a/system-parachains/asset-hub-paseo/Cargo.toml
+++ b/system-parachains/asset-hub-paseo/Cargo.toml
@@ -424,6 +424,7 @@ std = [
 	"parachains-common/std",
 	"paseo-primitives/std",
 	"paseo-runtime-constants/std",
+	"paseo-runtime/std",
 	"polkadot-core-primitives/std",
 	"polkadot-parachain-primitives/std",
 	"polkadot-runtime-common/std",

--- a/system-parachains/asset-hub-paseo/src/lib.rs
+++ b/system-parachains/asset-hub-paseo/src/lib.rs
@@ -602,6 +602,14 @@ pub enum ProxyType {
 	/// Contains `Staking` (validate, chill, kick), `StakingRcClient` (set_keys, purge_keys),
 	/// and `Utility` batching calls (batch, batch_all, force_batch).
 	StakingOperator,
+	/// Sudo-capable proxy whose one restriction is that it can never change or remove the sudo
+	/// key (directly or via any nesting wrapper). Intended for automations that need `sudo`
+	/// access: if the proxy key leaks, the sudo account itself stays recoverable. See
+	/// `call_can_change_sudo` for the exact set of forbidden calls.
+	///
+	/// The index is padded well above the contiguous range so upstream can keep appending proxy
+	/// types without colliding with this Paseo-specific variant.
+	SafeSudo = 100,
 }
 impl InstanceFilter<RuntimeCall> for ProxyType {
 	fn filter(&self, c: &RuntimeCall) -> bool {
@@ -780,6 +788,9 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 					RuntimeCall::Utility { .. } |
 					RuntimeCall::Multisig { .. }
 			),
+			// Behaves like `Any`, except it can never change or remove the sudo key (directly
+			// or via any nesting wrapper). See `call_can_change_sudo`.
+			ProxyType::SafeSudo => !call_can_change_sudo(c),
 		}
 	}
 
@@ -793,11 +804,53 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 			(ProxyType::Staking, ProxyType::StakingOperator) => true,
 			(
 				ProxyType::NonTransfer,
-				ProxyType::Assets | ProxyType::AssetOwner | ProxyType::AssetManager,
+				ProxyType::Assets |
+					ProxyType::AssetOwner |
+					ProxyType::AssetManager |
+					// `SafeSudo` can drive sudo, which `NonTransfer` cannot.
+					ProxyType::SafeSudo,
 			) => false,
 			(ProxyType::NonTransfer, _) => true,
 			_ => false,
 		}
+	}
+}
+
+/// Returns `true` if `call` could change or remove the sudo key, mint an escalation path to it,
+/// or defer/hide a call that later could (`Scheduler`/`Preimage`). The check is recursive so the
+/// forbidden leaf calls cannot be smuggled through `sudo`, `utility` batching, `dispatch_as`,
+/// etc. Used by the [`ProxyType::SafeSudo`] filter.
+///
+/// NOTE: when adding a pallet that can dispatch as `Root` or as the sudo account (new governance,
+/// new call wrappers, deferred dispatch), add it here or `SafeSudo` may leak a path to the key.
+fn call_can_change_sudo(call: &RuntimeCall) -> bool {
+	match call {
+		// Directly change or remove the sudo key.
+		RuntimeCall::Sudo(pallet_sudo::Call::set_key { .. }) |
+		RuntimeCall::Sudo(pallet_sudo::Call::remove_key { .. }) => true,
+		// Raw storage surgery can overwrite or delete `Sudo::Key`.
+		RuntimeCall::System(frame_system::Call::set_storage { .. }) |
+		RuntimeCall::System(frame_system::Call::kill_storage { .. }) |
+		RuntimeCall::System(frame_system::Call::kill_prefix { .. }) => true,
+		// Proxy management could mint a more powerful proxy (an escalation path to the key).
+		RuntimeCall::Proxy(..) => true,
+		// Deferred / hash-bounded dispatch escapes this filter at execution time; refuse it.
+		RuntimeCall::Scheduler(..) | RuntimeCall::Preimage(..) => true,
+		// Single-call wrappers: recurse into the wrapped call.
+		RuntimeCall::Sudo(pallet_sudo::Call::sudo { call }) |
+		RuntimeCall::Sudo(pallet_sudo::Call::sudo_unchecked_weight { call, .. }) |
+		RuntimeCall::Sudo(pallet_sudo::Call::sudo_as { call, .. }) |
+		RuntimeCall::Utility(pallet_utility::Call::as_derivative { call, .. }) |
+		RuntimeCall::Utility(pallet_utility::Call::dispatch_as { call, .. }) |
+		RuntimeCall::Utility(pallet_utility::Call::with_weight { call, .. }) |
+		RuntimeCall::Multisig(pallet_multisig::Call::as_multi_threshold_1 { call, .. }) =>
+			call_can_change_sudo(call),
+		// Batches: recurse into every wrapped call.
+		RuntimeCall::Utility(pallet_utility::Call::batch { calls }) |
+		RuntimeCall::Utility(pallet_utility::Call::batch_all { calls }) |
+		RuntimeCall::Utility(pallet_utility::Call::force_batch { calls }) =>
+			calls.iter().any(call_can_change_sudo),
+		_ => false,
 	}
 }
 
@@ -2895,6 +2948,79 @@ mod tests {
 		assert!(ProxyType::NonTransfer.is_superset(&ProxyType::ParaRegistration));
 		// Staking IS supertype of StakingOperator
 		assert!(ProxyType::Staking.is_superset(&ProxyType::StakingOperator));
+		// A weaker proxy must NOT be able to mint a SafeSudo proxy; only Any is its superset.
+		assert!(!ProxyType::NonTransfer.is_superset(&ProxyType::SafeSudo));
+		assert!(ProxyType::Any.is_superset(&ProxyType::SafeSudo));
+	}
+
+	#[test]
+	fn safe_sudo_proxy_filter_works() {
+		use alloc::boxed::Box;
+		use frame_support::traits::InstanceFilter;
+
+		let acc = || sp_runtime::MultiAddress::Id(AccountId::from([0u8; 32]));
+		let set_key = || RuntimeCall::Sudo(pallet_sudo::Call::set_key { new: acc() });
+		let remark = || RuntimeCall::System(frame_system::Call::remark { remark: vec![] });
+
+		// Directly key-mutating / escalating / deferred calls are blocked.
+		assert!(!ProxyType::SafeSudo.filter(&set_key()));
+		assert!(!ProxyType::SafeSudo.filter(&RuntimeCall::Sudo(pallet_sudo::Call::remove_key {})));
+		assert!(!ProxyType::SafeSudo
+			.filter(&RuntimeCall::System(frame_system::Call::set_storage { items: vec![] })));
+		assert!(!ProxyType::SafeSudo
+			.filter(&RuntimeCall::System(frame_system::Call::kill_storage { keys: vec![] })));
+		assert!(!ProxyType::SafeSudo.filter(&RuntimeCall::System(
+			frame_system::Call::kill_prefix { prefix: vec![], subkeys: 0 }
+		)));
+		assert!(!ProxyType::SafeSudo.filter(&RuntimeCall::Proxy(pallet_proxy::Call::add_proxy {
+			delegate: acc(),
+			proxy_type: ProxyType::Any,
+			delay: 0,
+		})));
+		assert!(!ProxyType::SafeSudo
+			.filter(&RuntimeCall::Scheduler(pallet_scheduler::Call::cancel { when: 0, index: 0 })));
+
+		// The same calls are still blocked when smuggled through wrappers.
+		assert!(!ProxyType::SafeSudo
+			.filter(&RuntimeCall::Sudo(pallet_sudo::Call::sudo { call: Box::new(set_key()) })));
+		assert!(!ProxyType::SafeSudo.filter(&RuntimeCall::Sudo(pallet_sudo::Call::sudo_as {
+			who: acc(),
+			call: Box::new(set_key()),
+		})));
+		assert!(!ProxyType::SafeSudo.filter(&RuntimeCall::Utility(
+			pallet_utility::Call::batch_all { calls: vec![remark(), set_key()] }
+		)));
+		// Deeply nested: sudo(batch_all([sudo(set_key)])).
+		assert!(!ProxyType::SafeSudo.filter(&RuntimeCall::Sudo(pallet_sudo::Call::sudo {
+			call: Box::new(RuntimeCall::Utility(pallet_utility::Call::batch_all {
+				calls: vec![RuntimeCall::Sudo(pallet_sudo::Call::sudo {
+					call: Box::new(set_key())
+				})],
+			})),
+		})));
+
+		// Ordinary sudo automation that never touches the key is allowed.
+		assert!(ProxyType::SafeSudo.filter(&remark()));
+		assert!(ProxyType::SafeSudo
+			.filter(&RuntimeCall::Sudo(pallet_sudo::Call::sudo { call: Box::new(remark()) })));
+		assert!(ProxyType::SafeSudo.filter(&RuntimeCall::Utility(
+			pallet_utility::Call::batch_all { calls: vec![remark(), remark()] }
+		)));
+
+		// SafeSudo is deliberately "Any minus the sudo key": it still permits powerful Root
+		// calls such as `Balances::force_transfer`, directly and via `sudo`. Only the sudo key
+		// itself is protected — a leaked key can move funds but cannot lock us out of sudo.
+		let force_transfer = || {
+			RuntimeCall::Balances(pallet_balances::Call::force_transfer {
+				source: acc(),
+				dest: acc(),
+				value: 1,
+			})
+		};
+		assert!(ProxyType::SafeSudo.filter(&force_transfer()));
+		assert!(ProxyType::SafeSudo.filter(&RuntimeCall::Sudo(pallet_sudo::Call::sudo {
+			call: Box::new(force_transfer())
+		})));
 	}
 
 	#[test]

--- a/system-parachains/asset-hub-paseo/src/lib.rs
+++ b/system-parachains/asset-hub-paseo/src/lib.rs
@@ -816,43 +816,7 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 	}
 }
 
-/// Returns `true` if `call` could change or remove the sudo key, mint an escalation path to it,
-/// or defer/hide a call that later could (`Scheduler`/`Preimage`). The check is recursive so the
-/// forbidden leaf calls cannot be smuggled through `sudo`, `utility` batching, `dispatch_as`,
-/// etc. Used by the [`ProxyType::SafeSudo`] filter.
-///
-/// NOTE: when adding a pallet that can dispatch as `Root` or as the sudo account (new governance,
-/// new call wrappers, deferred dispatch), add it here or `SafeSudo` may leak a path to the key.
-fn call_can_change_sudo(call: &RuntimeCall) -> bool {
-	match call {
-		// Directly change or remove the sudo key.
-		RuntimeCall::Sudo(pallet_sudo::Call::set_key { .. }) |
-		RuntimeCall::Sudo(pallet_sudo::Call::remove_key { .. }) => true,
-		// Raw storage surgery can overwrite or delete `Sudo::Key`.
-		RuntimeCall::System(frame_system::Call::set_storage { .. }) |
-		RuntimeCall::System(frame_system::Call::kill_storage { .. }) |
-		RuntimeCall::System(frame_system::Call::kill_prefix { .. }) => true,
-		// Proxy management could mint a more powerful proxy (an escalation path to the key).
-		RuntimeCall::Proxy(..) => true,
-		// Deferred / hash-bounded dispatch escapes this filter at execution time; refuse it.
-		RuntimeCall::Scheduler(..) | RuntimeCall::Preimage(..) => true,
-		// Single-call wrappers: recurse into the wrapped call.
-		RuntimeCall::Sudo(pallet_sudo::Call::sudo { call }) |
-		RuntimeCall::Sudo(pallet_sudo::Call::sudo_unchecked_weight { call, .. }) |
-		RuntimeCall::Sudo(pallet_sudo::Call::sudo_as { call, .. }) |
-		RuntimeCall::Utility(pallet_utility::Call::as_derivative { call, .. }) |
-		RuntimeCall::Utility(pallet_utility::Call::dispatch_as { call, .. }) |
-		RuntimeCall::Utility(pallet_utility::Call::with_weight { call, .. }) |
-		RuntimeCall::Multisig(pallet_multisig::Call::as_multi_threshold_1 { call, .. }) =>
-			call_can_change_sudo(call),
-		// Batches: recurse into every wrapped call.
-		RuntimeCall::Utility(pallet_utility::Call::batch { calls }) |
-		RuntimeCall::Utility(pallet_utility::Call::batch_all { calls }) |
-		RuntimeCall::Utility(pallet_utility::Call::force_batch { calls }) =>
-			calls.iter().any(call_can_change_sudo),
-		_ => false,
-	}
-}
+paseo_runtime_constants::impl_call_can_change_sudo!(RuntimeCall, block = [Scheduler, Preimage]);
 
 impl pallet_proxy::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;

--- a/system-parachains/bridge-hub-paseo/src/lib.rs
+++ b/system-parachains/bridge-hub-paseo/src/lib.rs
@@ -608,6 +608,49 @@ pub enum ProxyType {
 	CancelProxy,
 	/// Collator selection proxy. Can execute calls related to collator selection mechanism.
 	Collator,
+	/// Sudo-capable proxy whose one restriction is that it can never change or remove the sudo
+	/// key (directly or via any nesting wrapper). Intended for automations that need `sudo`
+	/// access: if the proxy key leaks, the sudo account itself stays recoverable. See
+	/// `call_can_change_sudo` for the exact set of forbidden calls.
+	///
+	/// The index is padded well above the contiguous range so upstream can keep appending proxy
+	/// types without colliding with this Paseo-specific variant.
+	SafeSudo = 100,
+}
+
+/// Returns `true` if `call` could change or remove the sudo key, or mint an escalation path to
+/// it. The check is recursive so the forbidden leaf calls cannot be smuggled through `sudo`,
+/// `utility` batching, `dispatch_as`, etc. Used by the [`ProxyType::SafeSudo`] filter.
+///
+/// NOTE: when adding a pallet that can dispatch as `Root` or as the sudo account (new governance,
+/// new call wrappers, deferred dispatch), add it here or `SafeSudo` may leak a path to the key.
+fn call_can_change_sudo(call: &RuntimeCall) -> bool {
+	match call {
+		// Directly change or remove the sudo key.
+		RuntimeCall::Sudo(pallet_sudo::Call::set_key { .. }) |
+		RuntimeCall::Sudo(pallet_sudo::Call::remove_key { .. }) => true,
+		// Raw storage surgery can overwrite or delete `Sudo::Key`.
+		RuntimeCall::System(frame_system::Call::set_storage { .. }) |
+		RuntimeCall::System(frame_system::Call::kill_storage { .. }) |
+		RuntimeCall::System(frame_system::Call::kill_prefix { .. }) => true,
+		// Proxy management could mint a more powerful proxy (an escalation path to the key).
+		RuntimeCall::Proxy(..) => true,
+		// Single-call wrappers: recurse into the wrapped call.
+		RuntimeCall::Sudo(pallet_sudo::Call::sudo { call }) |
+		RuntimeCall::Sudo(pallet_sudo::Call::sudo_unchecked_weight { call, .. }) |
+		RuntimeCall::Sudo(pallet_sudo::Call::sudo_as { call, .. }) |
+		RuntimeCall::Utility(pallet_utility::Call::as_derivative { call, .. }) |
+		RuntimeCall::Utility(pallet_utility::Call::dispatch_as { call, .. }) |
+		RuntimeCall::Utility(pallet_utility::Call::with_weight { call, .. }) |
+		RuntimeCall::Multisig(pallet_multisig::Call::as_multi_threshold_1 { call, .. }) =>
+			call_can_change_sudo(call),
+		// Batches: recurse into every wrapped call.
+		RuntimeCall::Utility(pallet_utility::Call::batch { calls }) |
+		RuntimeCall::Utility(pallet_utility::Call::batch_all { calls }) |
+		RuntimeCall::Utility(pallet_utility::Call::force_batch { calls }) =>
+			calls.iter().any(call_can_change_sudo),
+		_ => false,
+	}
 }
 
 impl InstanceFilter<RuntimeCall> for ProxyType {
@@ -642,6 +685,9 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 					RuntimeCall::Utility { .. } |
 					RuntimeCall::Multisig { .. }
 			),
+			// Behaves like `Any`, except it can never change or remove the sudo key (directly
+			// or via any nesting wrapper). See `call_can_change_sudo`.
+			ProxyType::SafeSudo => !call_can_change_sudo(c),
 		}
 	}
 

--- a/system-parachains/bridge-hub-paseo/src/lib.rs
+++ b/system-parachains/bridge-hub-paseo/src/lib.rs
@@ -618,40 +618,7 @@ pub enum ProxyType {
 	SafeSudo = 100,
 }
 
-/// Returns `true` if `call` could change or remove the sudo key, or mint an escalation path to
-/// it. The check is recursive so the forbidden leaf calls cannot be smuggled through `sudo`,
-/// `utility` batching, `dispatch_as`, etc. Used by the [`ProxyType::SafeSudo`] filter.
-///
-/// NOTE: when adding a pallet that can dispatch as `Root` or as the sudo account (new governance,
-/// new call wrappers, deferred dispatch), add it here or `SafeSudo` may leak a path to the key.
-fn call_can_change_sudo(call: &RuntimeCall) -> bool {
-	match call {
-		// Directly change or remove the sudo key.
-		RuntimeCall::Sudo(pallet_sudo::Call::set_key { .. }) |
-		RuntimeCall::Sudo(pallet_sudo::Call::remove_key { .. }) => true,
-		// Raw storage surgery can overwrite or delete `Sudo::Key`.
-		RuntimeCall::System(frame_system::Call::set_storage { .. }) |
-		RuntimeCall::System(frame_system::Call::kill_storage { .. }) |
-		RuntimeCall::System(frame_system::Call::kill_prefix { .. }) => true,
-		// Proxy management could mint a more powerful proxy (an escalation path to the key).
-		RuntimeCall::Proxy(..) => true,
-		// Single-call wrappers: recurse into the wrapped call.
-		RuntimeCall::Sudo(pallet_sudo::Call::sudo { call }) |
-		RuntimeCall::Sudo(pallet_sudo::Call::sudo_unchecked_weight { call, .. }) |
-		RuntimeCall::Sudo(pallet_sudo::Call::sudo_as { call, .. }) |
-		RuntimeCall::Utility(pallet_utility::Call::as_derivative { call, .. }) |
-		RuntimeCall::Utility(pallet_utility::Call::dispatch_as { call, .. }) |
-		RuntimeCall::Utility(pallet_utility::Call::with_weight { call, .. }) |
-		RuntimeCall::Multisig(pallet_multisig::Call::as_multi_threshold_1 { call, .. }) =>
-			call_can_change_sudo(call),
-		// Batches: recurse into every wrapped call.
-		RuntimeCall::Utility(pallet_utility::Call::batch { calls }) |
-		RuntimeCall::Utility(pallet_utility::Call::batch_all { calls }) |
-		RuntimeCall::Utility(pallet_utility::Call::force_batch { calls }) =>
-			calls.iter().any(call_can_change_sudo),
-		_ => false,
-	}
-}
+paseo_runtime_constants::impl_call_can_change_sudo!(RuntimeCall);
 
 impl InstanceFilter<RuntimeCall> for ProxyType {
 	fn filter(&self, c: &RuntimeCall) -> bool {

--- a/system-parachains/collectives-paseo/src/lib.rs
+++ b/system-parachains/collectives-paseo/src/lib.rs
@@ -435,43 +435,7 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 	}
 }
 
-/// Returns `true` if `call` could change or remove the sudo key, mint an escalation path to it,
-/// or defer/hide a call that later could (`Scheduler`/`Preimage`). The check is recursive so the
-/// forbidden leaf calls cannot be smuggled through `sudo`, `utility` batching, `dispatch_as`,
-/// etc. Used by the [`ProxyType::SafeSudo`] filter.
-///
-/// NOTE: when adding a pallet that can dispatch as `Root` or as the sudo account (new governance,
-/// new call wrappers, deferred dispatch), add it here or `SafeSudo` may leak a path to the key.
-fn call_can_change_sudo(call: &RuntimeCall) -> bool {
-	match call {
-		// Directly change or remove the sudo key.
-		RuntimeCall::Sudo(pallet_sudo::Call::set_key { .. }) |
-		RuntimeCall::Sudo(pallet_sudo::Call::remove_key { .. }) => true,
-		// Raw storage surgery can overwrite or delete `Sudo::Key`.
-		RuntimeCall::System(frame_system::Call::set_storage { .. }) |
-		RuntimeCall::System(frame_system::Call::kill_storage { .. }) |
-		RuntimeCall::System(frame_system::Call::kill_prefix { .. }) => true,
-		// Proxy management could mint a more powerful proxy (an escalation path to the key).
-		RuntimeCall::Proxy(..) => true,
-		// Deferred / hash-bounded dispatch escapes this filter at execution time; refuse it.
-		RuntimeCall::Scheduler(..) | RuntimeCall::Preimage(..) => true,
-		// Single-call wrappers: recurse into the wrapped call.
-		RuntimeCall::Sudo(pallet_sudo::Call::sudo { call }) |
-		RuntimeCall::Sudo(pallet_sudo::Call::sudo_unchecked_weight { call, .. }) |
-		RuntimeCall::Sudo(pallet_sudo::Call::sudo_as { call, .. }) |
-		RuntimeCall::Utility(pallet_utility::Call::as_derivative { call, .. }) |
-		RuntimeCall::Utility(pallet_utility::Call::dispatch_as { call, .. }) |
-		RuntimeCall::Utility(pallet_utility::Call::with_weight { call, .. }) |
-		RuntimeCall::Multisig(pallet_multisig::Call::as_multi_threshold_1 { call, .. }) =>
-			call_can_change_sudo(call),
-		// Batches: recurse into every wrapped call.
-		RuntimeCall::Utility(pallet_utility::Call::batch { calls }) |
-		RuntimeCall::Utility(pallet_utility::Call::batch_all { calls }) |
-		RuntimeCall::Utility(pallet_utility::Call::force_batch { calls }) =>
-			calls.iter().any(call_can_change_sudo),
-		_ => false,
-	}
-}
+paseo_runtime_constants::impl_call_can_change_sudo!(RuntimeCall, block = [Scheduler, Preimage]);
 
 impl pallet_proxy::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;

--- a/system-parachains/collectives-paseo/src/lib.rs
+++ b/system-parachains/collectives-paseo/src/lib.rs
@@ -336,6 +336,14 @@ pub enum ProxyType {
 	Ambassador,
 	/// Secretary proxy. Allows calls related to the Secretary collective
 	Secretary,
+	/// Sudo-capable proxy whose one restriction is that it can never change or remove the sudo
+	/// key (directly or via any nesting wrapper). Intended for automations that need `sudo`
+	/// access: if the proxy key leaks, the sudo account itself stays recoverable. See
+	/// `call_can_change_sudo` for the exact set of forbidden calls.
+	///
+	/// The index is padded well above the contiguous range so upstream can keep appending proxy
+	/// types without colliding with this Paseo-specific variant.
+	SafeSudo = 100,
 }
 impl InstanceFilter<RuntimeCall> for ProxyType {
 	fn filter(&self, c: &RuntimeCall) -> bool {
@@ -409,6 +417,9 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 					RuntimeCall::Utility { .. } |
 					RuntimeCall::Multisig { .. }
 			),
+			// Behaves like `Any`, except it can never change or remove the sudo key (directly
+			// or via any nesting wrapper). See `call_can_change_sudo`.
+			ProxyType::SafeSudo => !call_can_change_sudo(c),
 		}
 	}
 	fn is_superset(&self, o: &Self) -> bool {
@@ -416,9 +427,49 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 			(x, y) if x == y => true,
 			(ProxyType::Any, _) => true,
 			(_, ProxyType::Any) => false,
+			// `SafeSudo` can drive sudo, which `NonTransfer` cannot, so it is not a subset of it.
+			(ProxyType::NonTransfer, ProxyType::SafeSudo) => false,
 			(ProxyType::NonTransfer, _) => true,
 			_ => false,
 		}
+	}
+}
+
+/// Returns `true` if `call` could change or remove the sudo key, mint an escalation path to it,
+/// or defer/hide a call that later could (`Scheduler`/`Preimage`). The check is recursive so the
+/// forbidden leaf calls cannot be smuggled through `sudo`, `utility` batching, `dispatch_as`,
+/// etc. Used by the [`ProxyType::SafeSudo`] filter.
+///
+/// NOTE: when adding a pallet that can dispatch as `Root` or as the sudo account (new governance,
+/// new call wrappers, deferred dispatch), add it here or `SafeSudo` may leak a path to the key.
+fn call_can_change_sudo(call: &RuntimeCall) -> bool {
+	match call {
+		// Directly change or remove the sudo key.
+		RuntimeCall::Sudo(pallet_sudo::Call::set_key { .. }) |
+		RuntimeCall::Sudo(pallet_sudo::Call::remove_key { .. }) => true,
+		// Raw storage surgery can overwrite or delete `Sudo::Key`.
+		RuntimeCall::System(frame_system::Call::set_storage { .. }) |
+		RuntimeCall::System(frame_system::Call::kill_storage { .. }) |
+		RuntimeCall::System(frame_system::Call::kill_prefix { .. }) => true,
+		// Proxy management could mint a more powerful proxy (an escalation path to the key).
+		RuntimeCall::Proxy(..) => true,
+		// Deferred / hash-bounded dispatch escapes this filter at execution time; refuse it.
+		RuntimeCall::Scheduler(..) | RuntimeCall::Preimage(..) => true,
+		// Single-call wrappers: recurse into the wrapped call.
+		RuntimeCall::Sudo(pallet_sudo::Call::sudo { call }) |
+		RuntimeCall::Sudo(pallet_sudo::Call::sudo_unchecked_weight { call, .. }) |
+		RuntimeCall::Sudo(pallet_sudo::Call::sudo_as { call, .. }) |
+		RuntimeCall::Utility(pallet_utility::Call::as_derivative { call, .. }) |
+		RuntimeCall::Utility(pallet_utility::Call::dispatch_as { call, .. }) |
+		RuntimeCall::Utility(pallet_utility::Call::with_weight { call, .. }) |
+		RuntimeCall::Multisig(pallet_multisig::Call::as_multi_threshold_1 { call, .. }) =>
+			call_can_change_sudo(call),
+		// Batches: recurse into every wrapped call.
+		RuntimeCall::Utility(pallet_utility::Call::batch { calls }) |
+		RuntimeCall::Utility(pallet_utility::Call::batch_all { calls }) |
+		RuntimeCall::Utility(pallet_utility::Call::force_batch { calls }) =>
+			calls.iter().any(call_can_change_sudo),
+		_ => false,
 	}
 }
 

--- a/system-parachains/coretime-paseo/src/lib.rs
+++ b/system-parachains/coretime-paseo/src/lib.rs
@@ -564,6 +564,49 @@ pub enum ProxyType {
 	OnDemandPurchaser,
 	/// Collator selection proxy. Can execute calls related to collator selection mechanism.
 	Collator,
+	/// Sudo-capable proxy whose one restriction is that it can never change or remove the sudo
+	/// key (directly or via any nesting wrapper). Intended for automations that need `sudo`
+	/// access: if the proxy key leaks, the sudo account itself stays recoverable. See
+	/// `call_can_change_sudo` for the exact set of forbidden calls.
+	///
+	/// The index is padded well above the contiguous range so upstream can keep appending proxy
+	/// types without colliding with this Paseo-specific variant.
+	SafeSudo = 100,
+}
+
+/// Returns `true` if `call` could change or remove the sudo key, or mint an escalation path to
+/// it. The check is recursive so the forbidden leaf calls cannot be smuggled through `sudo`,
+/// `utility` batching, `dispatch_as`, etc. Used by the [`ProxyType::SafeSudo`] filter.
+///
+/// NOTE: when adding a pallet that can dispatch as `Root` or as the sudo account (new governance,
+/// new call wrappers, deferred dispatch), add it here or `SafeSudo` may leak a path to the key.
+fn call_can_change_sudo(call: &RuntimeCall) -> bool {
+	match call {
+		// Directly change or remove the sudo key.
+		RuntimeCall::Sudo(pallet_sudo::Call::set_key { .. }) |
+		RuntimeCall::Sudo(pallet_sudo::Call::remove_key { .. }) => true,
+		// Raw storage surgery can overwrite or delete `Sudo::Key`.
+		RuntimeCall::System(frame_system::Call::set_storage { .. }) |
+		RuntimeCall::System(frame_system::Call::kill_storage { .. }) |
+		RuntimeCall::System(frame_system::Call::kill_prefix { .. }) => true,
+		// Proxy management could mint a more powerful proxy (an escalation path to the key).
+		RuntimeCall::Proxy(..) => true,
+		// Single-call wrappers: recurse into the wrapped call.
+		RuntimeCall::Sudo(pallet_sudo::Call::sudo { call }) |
+		RuntimeCall::Sudo(pallet_sudo::Call::sudo_unchecked_weight { call, .. }) |
+		RuntimeCall::Sudo(pallet_sudo::Call::sudo_as { call, .. }) |
+		RuntimeCall::Utility(pallet_utility::Call::as_derivative { call, .. }) |
+		RuntimeCall::Utility(pallet_utility::Call::dispatch_as { call, .. }) |
+		RuntimeCall::Utility(pallet_utility::Call::with_weight { call, .. }) |
+		RuntimeCall::Multisig(pallet_multisig::Call::as_multi_threshold_1 { call, .. }) =>
+			call_can_change_sudo(call),
+		// Batches: recurse into every wrapped call.
+		RuntimeCall::Utility(pallet_utility::Call::batch { calls }) |
+		RuntimeCall::Utility(pallet_utility::Call::batch_all { calls }) |
+		RuntimeCall::Utility(pallet_utility::Call::force_batch { calls }) =>
+			calls.iter().any(call_can_change_sudo),
+		_ => false,
+	}
 }
 
 impl InstanceFilter<RuntimeCall> for ProxyType {
@@ -625,6 +668,9 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 					RuntimeCall::Utility { .. } |
 					RuntimeCall::Multisig { .. }
 			),
+			// Behaves like `Any`, except it can never change or remove the sudo key (directly
+			// or via any nesting wrapper). See `call_can_change_sudo`.
+			ProxyType::SafeSudo => !call_can_change_sudo(c),
 		}
 	}
 

--- a/system-parachains/coretime-paseo/src/lib.rs
+++ b/system-parachains/coretime-paseo/src/lib.rs
@@ -574,40 +574,7 @@ pub enum ProxyType {
 	SafeSudo = 100,
 }
 
-/// Returns `true` if `call` could change or remove the sudo key, or mint an escalation path to
-/// it. The check is recursive so the forbidden leaf calls cannot be smuggled through `sudo`,
-/// `utility` batching, `dispatch_as`, etc. Used by the [`ProxyType::SafeSudo`] filter.
-///
-/// NOTE: when adding a pallet that can dispatch as `Root` or as the sudo account (new governance,
-/// new call wrappers, deferred dispatch), add it here or `SafeSudo` may leak a path to the key.
-fn call_can_change_sudo(call: &RuntimeCall) -> bool {
-	match call {
-		// Directly change or remove the sudo key.
-		RuntimeCall::Sudo(pallet_sudo::Call::set_key { .. }) |
-		RuntimeCall::Sudo(pallet_sudo::Call::remove_key { .. }) => true,
-		// Raw storage surgery can overwrite or delete `Sudo::Key`.
-		RuntimeCall::System(frame_system::Call::set_storage { .. }) |
-		RuntimeCall::System(frame_system::Call::kill_storage { .. }) |
-		RuntimeCall::System(frame_system::Call::kill_prefix { .. }) => true,
-		// Proxy management could mint a more powerful proxy (an escalation path to the key).
-		RuntimeCall::Proxy(..) => true,
-		// Single-call wrappers: recurse into the wrapped call.
-		RuntimeCall::Sudo(pallet_sudo::Call::sudo { call }) |
-		RuntimeCall::Sudo(pallet_sudo::Call::sudo_unchecked_weight { call, .. }) |
-		RuntimeCall::Sudo(pallet_sudo::Call::sudo_as { call, .. }) |
-		RuntimeCall::Utility(pallet_utility::Call::as_derivative { call, .. }) |
-		RuntimeCall::Utility(pallet_utility::Call::dispatch_as { call, .. }) |
-		RuntimeCall::Utility(pallet_utility::Call::with_weight { call, .. }) |
-		RuntimeCall::Multisig(pallet_multisig::Call::as_multi_threshold_1 { call, .. }) =>
-			call_can_change_sudo(call),
-		// Batches: recurse into every wrapped call.
-		RuntimeCall::Utility(pallet_utility::Call::batch { calls }) |
-		RuntimeCall::Utility(pallet_utility::Call::batch_all { calls }) |
-		RuntimeCall::Utility(pallet_utility::Call::force_batch { calls }) =>
-			calls.iter().any(call_can_change_sudo),
-		_ => false,
-	}
-}
+paseo_runtime_constants::impl_call_can_change_sudo!(RuntimeCall);
 
 impl InstanceFilter<RuntimeCall> for ProxyType {
 	fn filter(&self, c: &RuntimeCall) -> bool {

--- a/system-parachains/coretime-paseo/src/tests.rs
+++ b/system-parachains/coretime-paseo/src/tests.rs
@@ -307,3 +307,70 @@ fn governance_authorize_upgrade_works() {
 		RuntimeOrigin,
 	>(GovernanceOrigin::Location(AssetHubLocation::get())));
 }
+
+#[test]
+fn safe_sudo_proxy_filter_works() {
+	use alloc::boxed::Box;
+	use frame_support::traits::InstanceFilter;
+
+	let acc = || sp_runtime::MultiAddress::Id(AccountId::from([0u8; 32]));
+	let set_key = || RuntimeCall::Sudo(pallet_sudo::Call::set_key { new: acc() });
+	let remark = || RuntimeCall::System(frame_system::Call::remark { remark: vec![] });
+
+	// A weaker proxy must NOT be able to mint a SafeSudo proxy; only Any is its superset.
+	assert!(!ProxyType::NonTransfer.is_superset(&ProxyType::SafeSudo));
+	assert!(ProxyType::Any.is_superset(&ProxyType::SafeSudo));
+
+	// Directly key-mutating / escalating calls are blocked.
+	assert!(!ProxyType::SafeSudo.filter(&set_key()));
+	assert!(!ProxyType::SafeSudo.filter(&RuntimeCall::Sudo(pallet_sudo::Call::remove_key {})));
+	assert!(!ProxyType::SafeSudo
+		.filter(&RuntimeCall::System(frame_system::Call::set_storage { items: vec![] })));
+	assert!(!ProxyType::SafeSudo
+		.filter(&RuntimeCall::System(frame_system::Call::kill_storage { keys: vec![] })));
+	assert!(!ProxyType::SafeSudo.filter(&RuntimeCall::System(frame_system::Call::kill_prefix {
+		prefix: vec![],
+		subkeys: 0
+	})));
+	assert!(!ProxyType::SafeSudo.filter(&RuntimeCall::Proxy(pallet_proxy::Call::add_proxy {
+		delegate: acc(),
+		proxy_type: ProxyType::Any,
+		delay: 0,
+	})));
+
+	// The same calls are still blocked when smuggled through wrappers.
+	assert!(!ProxyType::SafeSudo
+		.filter(&RuntimeCall::Sudo(pallet_sudo::Call::sudo { call: Box::new(set_key()) })));
+	assert!(!ProxyType::SafeSudo.filter(&RuntimeCall::Sudo(pallet_sudo::Call::sudo_as {
+		who: acc(),
+		call: Box::new(set_key()),
+	})));
+	assert!(!ProxyType::SafeSudo.filter(&RuntimeCall::Utility(pallet_utility::Call::batch_all {
+		calls: vec![remark(), set_key()]
+	})));
+	// Deeply nested: sudo(batch_all([sudo(set_key)])).
+	assert!(!ProxyType::SafeSudo.filter(&RuntimeCall::Sudo(pallet_sudo::Call::sudo {
+		call: Box::new(RuntimeCall::Utility(pallet_utility::Call::batch_all {
+			calls: vec![RuntimeCall::Sudo(pallet_sudo::Call::sudo { call: Box::new(set_key()) })],
+		})),
+	})));
+
+	// Ordinary sudo automation that never touches the key is allowed.
+	assert!(ProxyType::SafeSudo.filter(&remark()));
+	assert!(ProxyType::SafeSudo
+		.filter(&RuntimeCall::Sudo(pallet_sudo::Call::sudo { call: Box::new(remark()) })));
+
+	// SafeSudo is deliberately "Any minus the sudo key": it still permits powerful Root calls
+	// such as `Balances::force_transfer`, directly and via `sudo`. Only the sudo key itself is
+	// protected — a leaked key can move funds but cannot lock us out of sudo.
+	let force_transfer = || {
+		RuntimeCall::Balances(pallet_balances::Call::force_transfer {
+			source: acc(),
+			dest: acc(),
+			value: 1,
+		})
+	};
+	assert!(ProxyType::SafeSudo.filter(&force_transfer()));
+	assert!(ProxyType::SafeSudo
+		.filter(&RuntimeCall::Sudo(pallet_sudo::Call::sudo { call: Box::new(force_transfer()) })));
+}

--- a/system-parachains/people-paseo/src/lib.rs
+++ b/system-parachains/people-paseo/src/lib.rs
@@ -490,6 +490,49 @@ pub enum ProxyType {
 	IdentityJudgement,
 	/// Collator selection proxy. Can execute calls related to collator selection mechanism.
 	Collator,
+	/// Sudo-capable proxy whose one restriction is that it can never change or remove the sudo
+	/// key (directly or via any nesting wrapper). Intended for automations that need `sudo`
+	/// access: if the proxy key leaks, the sudo account itself stays recoverable. See
+	/// `call_can_change_sudo` for the exact set of forbidden calls.
+	///
+	/// The index is padded well above the contiguous range so upstream can keep appending proxy
+	/// types without colliding with this Paseo-specific variant.
+	SafeSudo = 100,
+}
+
+/// Returns `true` if `call` could change or remove the sudo key, or mint an escalation path to
+/// it. The check is recursive so the forbidden leaf calls cannot be smuggled through `sudo`,
+/// `utility` batching, `dispatch_as`, etc. Used by the [`ProxyType::SafeSudo`] filter.
+///
+/// NOTE: when adding a pallet that can dispatch as `Root` or as the sudo account (new governance,
+/// new call wrappers, deferred dispatch), add it here or `SafeSudo` may leak a path to the key.
+fn call_can_change_sudo(call: &RuntimeCall) -> bool {
+	match call {
+		// Directly change or remove the sudo key.
+		RuntimeCall::Sudo(pallet_sudo::Call::set_key { .. }) |
+		RuntimeCall::Sudo(pallet_sudo::Call::remove_key { .. }) => true,
+		// Raw storage surgery can overwrite or delete `Sudo::Key`.
+		RuntimeCall::System(frame_system::Call::set_storage { .. }) |
+		RuntimeCall::System(frame_system::Call::kill_storage { .. }) |
+		RuntimeCall::System(frame_system::Call::kill_prefix { .. }) => true,
+		// Proxy management could mint a more powerful proxy (an escalation path to the key).
+		RuntimeCall::Proxy(..) => true,
+		// Single-call wrappers: recurse into the wrapped call.
+		RuntimeCall::Sudo(pallet_sudo::Call::sudo { call }) |
+		RuntimeCall::Sudo(pallet_sudo::Call::sudo_unchecked_weight { call, .. }) |
+		RuntimeCall::Sudo(pallet_sudo::Call::sudo_as { call, .. }) |
+		RuntimeCall::Utility(pallet_utility::Call::as_derivative { call, .. }) |
+		RuntimeCall::Utility(pallet_utility::Call::dispatch_as { call, .. }) |
+		RuntimeCall::Utility(pallet_utility::Call::with_weight { call, .. }) |
+		RuntimeCall::Multisig(pallet_multisig::Call::as_multi_threshold_1 { call, .. }) =>
+			call_can_change_sudo(call),
+		// Batches: recurse into every wrapped call.
+		RuntimeCall::Utility(pallet_utility::Call::batch { calls }) |
+		RuntimeCall::Utility(pallet_utility::Call::batch_all { calls }) |
+		RuntimeCall::Utility(pallet_utility::Call::force_batch { calls }) =>
+			calls.iter().any(call_can_change_sudo),
+		_ => false,
+	}
 }
 impl InstanceFilter<RuntimeCall> for ProxyType {
 	fn filter(&self, c: &RuntimeCall) -> bool {
@@ -555,6 +598,9 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 					RuntimeCall::Utility { .. } |
 					RuntimeCall::Multisig { .. }
 			),
+			// Behaves like `Any`, except it can never change or remove the sudo key (directly
+			// or via any nesting wrapper). See `call_can_change_sudo`.
+			ProxyType::SafeSudo => !call_can_change_sudo(c),
 		}
 	}
 

--- a/system-parachains/people-paseo/src/lib.rs
+++ b/system-parachains/people-paseo/src/lib.rs
@@ -500,40 +500,7 @@ pub enum ProxyType {
 	SafeSudo = 100,
 }
 
-/// Returns `true` if `call` could change or remove the sudo key, or mint an escalation path to
-/// it. The check is recursive so the forbidden leaf calls cannot be smuggled through `sudo`,
-/// `utility` batching, `dispatch_as`, etc. Used by the [`ProxyType::SafeSudo`] filter.
-///
-/// NOTE: when adding a pallet that can dispatch as `Root` or as the sudo account (new governance,
-/// new call wrappers, deferred dispatch), add it here or `SafeSudo` may leak a path to the key.
-fn call_can_change_sudo(call: &RuntimeCall) -> bool {
-	match call {
-		// Directly change or remove the sudo key.
-		RuntimeCall::Sudo(pallet_sudo::Call::set_key { .. }) |
-		RuntimeCall::Sudo(pallet_sudo::Call::remove_key { .. }) => true,
-		// Raw storage surgery can overwrite or delete `Sudo::Key`.
-		RuntimeCall::System(frame_system::Call::set_storage { .. }) |
-		RuntimeCall::System(frame_system::Call::kill_storage { .. }) |
-		RuntimeCall::System(frame_system::Call::kill_prefix { .. }) => true,
-		// Proxy management could mint a more powerful proxy (an escalation path to the key).
-		RuntimeCall::Proxy(..) => true,
-		// Single-call wrappers: recurse into the wrapped call.
-		RuntimeCall::Sudo(pallet_sudo::Call::sudo { call }) |
-		RuntimeCall::Sudo(pallet_sudo::Call::sudo_unchecked_weight { call, .. }) |
-		RuntimeCall::Sudo(pallet_sudo::Call::sudo_as { call, .. }) |
-		RuntimeCall::Utility(pallet_utility::Call::as_derivative { call, .. }) |
-		RuntimeCall::Utility(pallet_utility::Call::dispatch_as { call, .. }) |
-		RuntimeCall::Utility(pallet_utility::Call::with_weight { call, .. }) |
-		RuntimeCall::Multisig(pallet_multisig::Call::as_multi_threshold_1 { call, .. }) =>
-			call_can_change_sudo(call),
-		// Batches: recurse into every wrapped call.
-		RuntimeCall::Utility(pallet_utility::Call::batch { calls }) |
-		RuntimeCall::Utility(pallet_utility::Call::batch_all { calls }) |
-		RuntimeCall::Utility(pallet_utility::Call::force_batch { calls }) =>
-			calls.iter().any(call_can_change_sudo),
-		_ => false,
-	}
-}
+paseo_runtime_constants::impl_call_can_change_sudo!(RuntimeCall);
 impl InstanceFilter<RuntimeCall> for ProxyType {
 	fn filter(&self, c: &RuntimeCall) -> bool {
 		match self {


### PR DESCRIPTION
## What

Adds a new **`SafeSudo`** proxy type to all six Paseo runtimes (relay, asset-hub, bridge-hub, collectives, coretime, people).

It behaves like `Any` **except it can never change or remove the sudo key**. It is the only proxy type in any Paseo runtime that grants `Sudo` access, so it enables sudo automations whose key can leak without risking permanent loss of sudo.

## Why recursion is required

- `pallet-sudo`'s `ensure_sudo` accepts **Root**, so `sudo.sudo(sudo.set_key(attacker))` succeeds.
- `sudo.sudo*`, `sudo_as`, and root-origin `utility.batch*` / `dispatch_as` / `with_weight` dispatch their inner calls with `dispatch_bypass_filter`, so the proxy origin filter does **not** propagate into wrapped calls.

The filter therefore recurses through every wrapper and rejects the call tree if it contains a sudo-key-affecting leaf.

**Forbidden (recursively):** `Sudo::{set_key, remove_key}`, `System::{set_storage, kill_storage, kill_prefix}`, the entire `Proxy` pallet (escalation), and `Scheduler` / `Preimage` (deferred / hash-hidden dispatch).
**Wrappers recursed into:** `sudo`, `sudo_unchecked_weight`, `sudo_as`, `utility` batches + `as_derivative` / `dispatch_as` / `with_weight`, and `multisig::as_multi_threshold_1`.

## Notes

- **Padded index** `SafeSudo = 100` everywhere, so upstream can keep appending proxy types without colliding (the Rust discriminant is the SCALE/metadata index).
- `is_superset` gains `(NonTransfer, SafeSudo) => false` on the relay and collectives (which have a `NonTransfer ⊇ _` catch-all) so a weaker proxy cannot mint a `SafeSudo` proxy.
- Forwards `paseo-runtime/std` in asset-hub so its lib tests build under `std`.

## Scope boundary (documented + tested)

`SafeSudo` is intentionally *"Any minus the sudo key"*: it still permits powerful Root calls such as `Balances::force_transfer`. A leaked key can move funds but cannot lock us out of sudo. A code comment on each `call_can_change_sudo` flags that any future pallet able to dispatch as Root/sudo must be added there.

## Tests

Unit tests on asset-hub (own enum, Scheduler present) and coretime (no Scheduler) cover the direct, nested (incl. `sudo(batch_all([sudo(set_key)]))`) and benign cases, and assert `force_transfer` stays allowed. `cargo check` passes for all six runtimes; rustfmt clean.