### PR TITLE
Remove new slot durations until 2.3.1 is live

### DIFF
--- a/system-parachains/asset-hub-paseo/src/lib.rs
+++ b/system-parachains/asset-hub-paseo/src/lib.rs
@@ -208,7 +208,9 @@ pub fn native_version() -> NativeVersion {
 }
 
 /// Asset Hub Paseo uses a 24s Aura slot duration.
-pub const SLOT_DURATION: u64 = 24_000;
+/// TODO: Uncomment me after 2.3.1 is on chain
+/// pub const SLOT_DURATION: u64 = 24_000;
+pub use system_parachains_constants::SLOT_DURATION;
 
 parameter_types! {
 	pub const Version: RuntimeVersion = VERSION;

--- a/system-parachains/people-paseo/src/lib.rs
+++ b/system-parachains/people-paseo/src/lib.rs
@@ -183,7 +183,9 @@ pub fn native_version() -> NativeVersion {
 }
 
 /// People Paseo uses a 24s Aura slot duration.
-pub const SLOT_DURATION: u64 = 24_000;
+/// TODO: Uncomment me after 2.3.1 is on chain
+/// pub const SLOT_DURATION: u64 = 24_000;
+pub use system_parachains_constants::SLOT_DURATION;
 
 parameter_types! {
 	pub const Version: RuntimeVersion = VERSION;


### PR DESCRIPTION
The new slots durations meant to be introduced in 2.3.1 is creating upgrade issues in paseo. The upgrade shouldn't be problematic (and actually it's not in Polkadot) as the new aura version should update the storage on runtime upgrade, but , we're experiencing an issue originated by the slot mismatch cause the relay chain isn't seeing the new runtime on time, then the collators try to produce blocks using the new runtime but the relay chain cannot finalize them as it tries to execute them agains the old/incompatible runtime (because of the slot durations) and hence the network is stuck. We will go to 2.3.1 without this change and include the new slot duration in the next upgrade, this is ok as by that time the relay chain will already contain the 2.3.1 AH runtime which includes the needed `on_runtime_upgrade` function, so the new slots will be correctly computed that time. 

I'm not sure about the root cause of this issue given it didn't happen on Polkadot, but my two cents on it's related to Paseo AH not being decentralized enough (just 2 collators) + elastic scaling active -> more forks and easiness to find such a de-sync bug