### PR TITLE
fix(xcm): permit protected-asset (digital-dollar) teleport settlement across AH<->People

### DIFF
--- a/pallets/value-transfer-auth/src/guarded_transactor.rs
+++ b/pallets/value-transfer-auth/src/guarded_transactor.rs
@@ -66,10 +66,15 @@ where
 		if holding_contains_protected_asset::<ProtectedAssetLocation>(&what) &&
 			block_flag::is_blocked()
 		{
-			let from_trusted_origin = context
-				.and_then(|c| c.origin.as_ref())
-				.map(|o| TrustedSiblings::contains(o))
-				.unwrap_or(false);
+			// A cleared origin (`None`) is the teleport-settlement shape: `InitiateTeleport`
+			// pushes `ClearOrigin` before `DepositAsset`, so by the time we deposit the origin
+			// has been nulled. Provenance was already enforced one instruction earlier at
+			// `ReceiveTeleportedAsset` by `IsTeleporter`/`ExternalAssetFromAssetHub`, so we permit
+			// the settled inflow. A `Some(untrusted)` origin is still rejected.
+			let from_trusted_origin = match context.and_then(|c| c.origin.as_ref()) {
+				Some(o) => TrustedSiblings::contains(o),
+				None => true,
+			};
 			if !from_trusted_origin {
 				return Err((what, XcmError::NoPermission));
 			}
@@ -86,10 +91,13 @@ where
 		if holding_contains_protected_asset::<ProtectedAssetLocation>(&what) &&
 			block_flag::is_blocked()
 		{
-			let from_trusted_origin = context
-				.and_then(|c| c.origin.as_ref())
-				.map(|o| TrustedSiblings::contains(o))
-				.unwrap_or(false);
+			// Mirror of `deposit_asset`: permit a cleared (`None`) origin, which is the
+			// post-`ClearOrigin` teleport-settlement shape whose provenance was already checked at
+			// `ReceiveTeleportedAsset`; still reject a `Some(untrusted)` origin.
+			let from_trusted_origin = match context.and_then(|c| c.origin.as_ref()) {
+				Some(o) => TrustedSiblings::contains(o),
+				None => true,
+			};
 			if !from_trusted_origin {
 				return Err((what, XcmError::NoPermission));
 			}

--- a/pallets/value-transfer-auth/src/tests/guarded_transactor.rs
+++ b/pallets/value-transfer-auth/src/tests/guarded_transactor.rs
@@ -223,12 +223,17 @@ fn withdraw_non_protected_asset_passes_when_blocked() {
 }
 
 #[test]
-fn deposit_protected_asset_when_blocked_rejects() {
+fn deposit_protected_asset_with_cleared_origin_passes_when_blocked() {
+	// A cleared origin (`context.origin == None`) is the post-`ClearOrigin` teleport-settlement
+	// shape. It is permitted even while blocked: provenance was already enforced at
+	// `ReceiveTeleportedAsset`, before `ClearOrigin` nulled the origin.
 	let _guard = reset();
+	let ctx = context();
 
-	let result = Guard::deposit_asset(holding(protected_asset()), &Location::here(), None);
-	assert!(matches!(result, Err((_, XcmError::NoPermission))));
-	assert_eq!(DEPOSIT_CALLS.load(Ordering::SeqCst), 0);
+	let result =
+		GuardWithTrusted::deposit_asset(holding(protected_asset()), &Location::here(), Some(&ctx));
+	assert!(result.is_ok());
+	assert_eq!(DEPOSIT_CALLS.load(Ordering::SeqCst), 1);
 }
 
 #[test]
@@ -335,11 +340,32 @@ fn deposit_from_untrusted_origin_rejected_when_blocked() {
 }
 
 #[test]
-fn deposit_with_no_context_rejected_when_blocked() {
+fn deposit_with_surplus_cleared_origin_passes_when_blocked() {
+	// The executor may settle teleport deposits through the `_with_surplus` variant; it must
+	// permit the cleared-origin shape identically to `deposit_asset`.
 	let _guard = reset();
+	let ctx = context();
 
-	let result =
-		GuardWithTrusted::deposit_asset(holding(protected_asset()), &Location::here(), None);
+	let result = GuardWithTrusted::deposit_asset_with_surplus(
+		holding(protected_asset()),
+		&Location::here(),
+		Some(&ctx),
+	);
+	assert!(result.is_ok());
+	assert_eq!(DEPOSIT_CALLS.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn deposit_with_surplus_untrusted_origin_rejected_when_blocked() {
+	// Regression guard: a `Some(untrusted)` origin is still rejected on the `_with_surplus` path.
+	let _guard = reset();
+	let ctx = context_with_origin(Location::new(1, [Parachain(9999)]));
+
+	let result = GuardWithTrusted::deposit_asset_with_surplus(
+		holding(protected_asset()),
+		&Location::here(),
+		Some(&ctx),
+	);
 	assert!(matches!(result, Err((_, XcmError::NoPermission))));
 	assert_eq!(DEPOSIT_CALLS.load(Ordering::SeqCst), 0);
 }

--- a/system-parachains/asset-hub-paseo/src/lib.rs
+++ b/system-parachains/asset-hub-paseo/src/lib.rs
@@ -202,7 +202,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_name: Cow::Borrowed("asset-hub-paseo"),
 	spec_name: Cow::Borrowed("asset-hub-paseo"),
 	authoring_version: 1,
-	spec_version: 2_004_000,
+	spec_version: 2_004_001,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 16,
@@ -3232,6 +3232,33 @@ mod benches {
 #[cfg(feature = "runtime-benchmarks")]
 use benches::*;
 
+/// Temporarily lifts the value-transfer block flag for the duration of a runtime-API call,
+/// restoring the previous value on drop.
+///
+/// Dry-runs (`DryRunApi`) do not execute transaction extensions, so
+/// `AuthorizeValueTransfer::prepare` never calls `block_flag::unblock()` during fee-estimation.
+/// Without this, `ProtectedAssetTransactor::withdraw_asset` returns `NoPermission` for the
+/// protected asset and `forwarded_xcms` comes back empty, black-screening the client. The RAII
+/// guard save-and-restores the prior flag (rather than a blind `block()`), which is mandatory
+/// because `block_flag` is a Wasm `static mut` that persists across runtime-API calls and is not
+/// rolled back by the dry-run overlay.
+fn value_transfer_block_flag_scope() -> impl Drop {
+	use indiv_pallet_value_transfer_auth::extension::block_flag;
+	struct Restore(bool);
+	impl Drop for Restore {
+		fn drop(&mut self) {
+			if self.0 {
+				block_flag::block();
+			} else {
+				block_flag::unblock();
+			}
+		}
+	}
+	let prev = block_flag::is_blocked();
+	block_flag::unblock();
+	Restore(prev)
+}
+
 pallet_revive::impl_runtime_apis_plus_revive_traits!(
 	Runtime,
 	Revive,
@@ -3428,10 +3455,12 @@ pallet_revive::impl_runtime_apis_plus_revive_traits!(
 
 	impl xcm_runtime_apis::dry_run::DryRunApi<Block, RuntimeCall, RuntimeEvent, OriginCaller> for Runtime {
 		fn dry_run_call(origin: OriginCaller, call: RuntimeCall, result_xcms_version: XcmVersion) -> Result<CallDryRunEffects<RuntimeEvent>, XcmDryRunApiError> {
+			let _guard = value_transfer_block_flag_scope();
 			PolkadotXcm::dry_run_call::<Runtime, xcm_config::XcmRouter, OriginCaller, RuntimeCall>(origin, call, result_xcms_version)
 		}
 
 		fn dry_run_xcm(origin_location: VersionedLocation, xcm: VersionedXcm<RuntimeCall>) -> Result<XcmDryRunEffects<RuntimeEvent>, XcmDryRunApiError> {
+			let _guard = value_transfer_block_flag_scope();
 			PolkadotXcm::dry_run_xcm::<xcm_config::XcmRouter>(origin_location, xcm)
 		}
 	}

--- a/system-parachains/people-paseo/src/lib.rs
+++ b/system-parachains/people-paseo/src/lib.rs
@@ -176,7 +176,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: Cow::Borrowed("people-paseo"),
 	impl_name: Cow::Borrowed("people-paseo"),
 	authoring_version: 1,
-	spec_version: 2_004_000,
+	spec_version: 2_004_001,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
@@ -1044,6 +1044,33 @@ mod benches {
 #[cfg(feature = "runtime-benchmarks")]
 use benches::*;
 
+/// Temporarily lifts the value-transfer block flag for the duration of a runtime-API call,
+/// restoring the previous value on drop.
+///
+/// Dry-runs (`DryRunApi`) do not execute transaction extensions, so
+/// `AuthorizeValueTransfer::prepare` never calls `block_flag::unblock()` during fee-estimation.
+/// This lets a client fee-estimate a People->AH withdraw (`WithdrawAsset` of the protected asset
+/// executed on People) without `ProtectedAssetTransactor::withdraw_asset` returning `NoPermission`
+/// and emptying `forwarded_xcms`. The RAII guard save-and-restores the prior flag (rather than a
+/// blind `block()`), which is mandatory because `block_flag` is a Wasm `static mut` that persists
+/// across runtime-API calls and is not rolled back by the dry-run overlay.
+fn value_transfer_block_flag_scope() -> impl Drop {
+	use indiv_pallet_value_transfer_auth::extension::block_flag;
+	struct Restore(bool);
+	impl Drop for Restore {
+		fn drop(&mut self) {
+			if self.0 {
+				block_flag::block();
+			} else {
+				block_flag::unblock();
+			}
+		}
+	}
+	let prev = block_flag::is_blocked();
+	block_flag::unblock();
+	Restore(prev)
+}
+
 impl_runtime_apis! {
 	impl sp_consensus_aura::AuraApi<Block, AuraId> for Runtime {
 		fn slot_duration() -> sp_consensus_aura::SlotDuration {
@@ -1230,10 +1257,12 @@ impl_runtime_apis! {
 
 	impl xcm_runtime_apis::dry_run::DryRunApi<Block, RuntimeCall, RuntimeEvent, OriginCaller> for Runtime {
 		fn dry_run_call(origin: OriginCaller, call: RuntimeCall, result_xcms_version: XcmVersion) -> Result<CallDryRunEffects<RuntimeEvent>, XcmDryRunApiError> {
+			let _guard = value_transfer_block_flag_scope();
 			PolkadotXcm::dry_run_call::<Runtime, xcm_config::XcmRouter, OriginCaller, RuntimeCall>(origin, call, result_xcms_version)
 		}
 
 		fn dry_run_xcm(origin_location: VersionedLocation, xcm: VersionedXcm<RuntimeCall>) -> Result<XcmDryRunEffects<RuntimeEvent>, XcmDryRunApiError> {
+			let _guard = value_transfer_block_flag_scope();
 			PolkadotXcm::dry_run_xcm::<xcm_config::XcmRouter>(origin_location, xcm)
 		}
 	}


### PR DESCRIPTION
## Summary

Fixes the digital-dollar (external/protected asset) cross-chain teleport between Asset Hub and People, which is silently broken by the `ProtectedAssetTransactor` value-transfer guard. Two independent defects, one shared-pallet fix plus a dry-run accommodation. Bumps both runtimes `2_004_000 → 2_004_001`.

Reproduced end-to-end on a chopsticks fork of live Paseo AH+People.

## Root cause

The `ProtectedAssetTransactor` (vendored `indiv-pallet-value-transfer-auth`) relies on (a) the process-global `block_flag` (default `true`) being turned off by the `AuthorizeValueTransfer` tx-extension, and (b) `context.origin` surviving to `DepositAsset`. Neither holds on the real teleport path.

1. **People deposit — a real transfer failure.** `InitiateTeleport` (xcm-executor) pushes `ClearOrigin`, forwarding `[ReceiveTeleportedAsset, ClearOrigin, BuyExecution, DepositAsset]`. People executes this from the **XCMP queue** (no tx-extension → `block_flag` stays `true`), and `ClearOrigin` nulls the origin, so `deposit_asset`'s `from_trusted_origin` check fails → `NoPermission` at the `DepositAsset` instruction. No teleport of the external asset can ever settle.
2. **Asset Hub fee-estimation.** `DryRunApi::dry_run_call`/`dry_run_xcm` do not run tx-extensions, so `AuthorizeValueTransfer::prepare()` never unblocks the flag; `withdraw_asset` returns `NoPermission` and the dry-run yields empty `forwarded_xcms`. Wallets that fee-estimate an authorized transfer get no result (client-side crash / black screen).

Both are latent in the pallet as-is; the only prior coverage pre-injects the sibling origin and never drives a real `ClearOrigin`-bearing teleport through the executor.

## Changes

**`pallets/value-transfer-auth/src/guarded_transactor.rs` — the substantive fix (shared, inherited by AH + People):**
- `deposit_asset` and `deposit_asset_with_surplus`: treat a **cleared (`None`) origin as trusted**. This is the post-`ClearOrigin` teleport-settlement shape, and provenance was already enforced one instruction earlier at `ReceiveTeleportedAsset` by `IsTeleporter` (`ExternalAssetFromAssetHub`/system relay). A `Some(untrusted)` origin is still rejected.
- `withdraw_asset`, `internal_transfer_asset`, `transfer_asset`, `mint_asset` (and `_with_surplus` variants) are **unchanged** — the outflow/movement/mint guards keep hard-blocking on the flag.

**`system-parachains/{asset-hub-paseo,people-paseo}/src/lib.rs` — dry-run accommodation:**
- Wrap `DryRunApi::{dry_run_call,dry_run_xcm}` with a small RAII `value_transfer_block_flag_scope()` that unblocks the flag for the estimation and **restores the prior value on drop** (safe against wasm-instance reuse). Estimation-only; the real extrinsic path is unchanged and still requires the `AuthorizeValueTransfer` signature.
- `spec_version: 2_004_000 → 2_004_001` on both. `transaction_version` unchanged (no call/extension encoding change). No storage migration.

## Safety

- **Inflow gating unchanged and runs before `ClearOrigin`.** The external asset can only enter holding via `ReceiveTeleportedAsset`, gated by `IsTeleporter`; `IsReserve` explicitly excludes it (teleport-only). Permitting the `None`-origin deposit only settles an inflow whose provenance was already proven — no new lateral-injection path (`Some(untrusted)` still rejects).
- **Emergency-freeze teeth intact.** `deposit_asset` is pure inflow; withdraw/transfer/mint guards are byte-unchanged, so a set `block_flag` still hard-stops all protected-asset movement for unauthorized actors.
- **Dry-run restores the flag**, so a subsequent unauthorized extrinsic still finds it blocked. The `block_flag` default is unchanged.

## Testing

- **Pallet unit tests:** `cargo test -p indiv-pallet-value-transfer-auth` → 31 passed (added: cleared-origin deposit succeeds while blocked, `_with_surplus` parity; kept regressions: untrusted origin rejected, withdraw still blocked).
- **Chopsticks fork of live Paseo AH+People** with `wasm-override` (this runtime):
  - AH `dry_run_call` of `execute([WithdrawAsset(pUSD), BuyExecution, InitiateTeleport→People])`: `forwarded_xcms` **non-empty** (was empty on live).
  - People `dryRunXcm` of the real `[ReceiveTeleportedAsset, ClearOrigin, BuyExecution, DepositAsset]`: **`Complete`** (was `Incomplete{index:3, NoPermission}` on live).
  - Regression: untrusted-origin teleport → `Incomplete{index:0, UntrustedTeleportLocation}` (still rejected).

## Follow-up

The same latent deposit incompatibility exists in the upstream `individuality-community` copy of the pallet (source-identical); the identical `guarded_transactor.rs` change should be upstreamed there.
