### PR TITLE
feat(asset-hub,people): set SS58Prefix to 42 to match Paseo

### DIFF
--- a/chain-specs/asset-hub-paseo-local.json
+++ b/chain-specs/asset-hub-paseo-local.json
@@ -6,8 +6,8 @@
   "telemetryEndpoints": null,
   "protocolId": "ah-pas",
   "properties": {
-    "ss58Format": "0",
-    "tokenDecimals": "10",
+    "ss58Format": 42,
+    "tokenDecimals": 10,
     "tokenSymbol": "PAS"
   },
   "codeSubstitutes": {},

--- a/chain-specs/bridge-hub-paseo-local.json
+++ b/chain-specs/bridge-hub-paseo-local.json
@@ -6,8 +6,8 @@
   "telemetryEndpoints": null,
   "protocolId": "bh-pas",
   "properties": {
-    "ss58Format": "0",
-    "tokenDecimals": "10",
+    "ss58Format": 42,
+    "tokenDecimals": 10,
     "tokenSymbol": "PAS"
   },
   "codeSubstitutes": {},

--- a/chain-specs/bulletin-paseo-local.json
+++ b/chain-specs/bulletin-paseo-local.json
@@ -6,8 +6,8 @@
   "telemetryEndpoints": null,
   "protocolId": "bl-pas",
   "properties": {
-    "ss58Format": "42",
-    "tokenDecimals": "10",
+    "ss58Format": 42,
+    "tokenDecimals": 10,
     "tokenSymbol": "PAS"
   },
   "codeSubstitutes": {},

--- a/chain-specs/bulletin-paseo.json
+++ b/chain-specs/bulletin-paseo.json
@@ -6,8 +6,8 @@
   "telemetryEndpoints": null,
   "protocolId": "bl-pas",
   "properties": {
-    "ss58Format": "42",
-    "tokenDecimals": "10",
+    "ss58Format": 42,
+    "tokenDecimals": 10,
     "tokenSymbol": "PAS"
   },
   "codeSubstitutes": {},

--- a/chain-specs/collectives-paseo-local.json
+++ b/chain-specs/collectives-paseo-local.json
@@ -6,8 +6,8 @@
   "telemetryEndpoints": null,
   "protocolId": "col-pas",
   "properties": {
-    "ss58Format": "0",
-    "tokenDecimals": "10",
+    "ss58Format": 42,
+    "tokenDecimals": 10,
     "tokenSymbol": "PAS"
   },
   "codeSubstitutes": {},

--- a/chain-specs/coretime-paseo-local.json
+++ b/chain-specs/coretime-paseo-local.json
@@ -6,8 +6,8 @@
   "telemetryEndpoints": null,
   "protocolId": "ct-pas",
   "properties": {
-    "ss58Format": "0",
-    "tokenDecimals": "10",
+    "ss58Format": 42,
+    "tokenDecimals": 10,
     "tokenSymbol": "PAS"
   },
   "codeSubstitutes": {},

--- a/chain-specs/paseo-dev.json
+++ b/chain-specs/paseo-dev.json
@@ -6,8 +6,8 @@
   "telemetryEndpoints": null,
   "protocolId": "pas",
   "properties": {
-    "ss58Format": "0",
-    "tokenDecimals": "10",
+    "ss58Format": 42,
+    "tokenDecimals": 10,
     "tokenSymbol": "PAS"
   },
   "codeSubstitutes": {},

--- a/chain-specs/paseo-local.json
+++ b/chain-specs/paseo-local.json
@@ -6,8 +6,8 @@
   "telemetryEndpoints": null,
   "protocolId": "pas",
   "properties": {
-    "ss58Format": "0",
-    "tokenDecimals": "10",
+    "ss58Format": 42,
+    "tokenDecimals": 10,
     "tokenSymbol": "PAS"
   },
   "codeSubstitutes": {},

--- a/chain-specs/paseo-substitute.json
+++ b/chain-specs/paseo-substitute.json
@@ -8,8 +8,8 @@
   "telemetryEndpoints": null,
   "protocolId": "pad",
   "properties": {
-    "ss58Format": "42",
-    "tokenDecimals": "10",
+    "ss58Format": 42,
+    "tokenDecimals": 10,
     "tokenSymbol": "PAS"
   },
   "codeSubstitutes": {},

--- a/chain-specs/people-paseo-local.json
+++ b/chain-specs/people-paseo-local.json
@@ -6,8 +6,8 @@
   "telemetryEndpoints": null,
   "protocolId": "pc-pas",
   "properties": {
-    "ss58Format": "0",
-    "tokenDecimals": "10",
+    "ss58Format": 42,
+    "tokenDecimals": 10,
     "tokenSymbol": "PAS"
   },
   "codeSubstitutes": {},

--- a/relay/paseo/constants/src/lib.rs
+++ b/relay/paseo/constants/src/lib.rs
@@ -20,6 +20,13 @@ extern crate alloc;
 
 pub mod weights;
 
+/// The address format used across the whole Paseo network.
+///
+/// The relay chain and every system chain share it, so that an account is displayed the same way
+/// wherever it is used. Runtimes must not redefine it: wire `frame_system::Config::SS58Prefix` to
+/// this constant.
+pub const SS58_PREFIX: u8 = 42;
+
 /// Generates `call_can_change_sudo`, the recursive guard used by the `SafeSudo` proxy type.
 ///
 /// `SafeSudo` behaves like `Any` but must never let a (possibly nested) call change or remove the

--- a/relay/paseo/src/lib.rs
+++ b/relay/paseo/src/lib.rs
@@ -188,7 +188,7 @@ pub fn native_version() -> NativeVersion {
 
 parameter_types! {
 	pub const Version: RuntimeVersion = VERSION;
-	pub const SS58Prefix: u8 = 42;
+	pub const SS58Prefix: u8 = paseo_runtime_constants::SS58_PREFIX;
 }
 
 /// Pallets that are blocked for user calls after the AHM.

--- a/system-parachains/asset-hub-paseo/src/lib.rs
+++ b/system-parachains/asset-hub-paseo/src/lib.rs
@@ -202,7 +202,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_name: Cow::Borrowed("asset-hub-paseo"),
 	spec_name: Cow::Borrowed("asset-hub-paseo"),
 	authoring_version: 1,
-	spec_version: 2_004_001,
+	spec_version: 2_004_002,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 16,
@@ -246,7 +246,8 @@ parameter_types! {
 		})
 		.avg_block_initialization(AVERAGE_ON_INITIALIZE_RATIO)
 		.build_or_panic();
-	pub const SS58Prefix: u8 = 0;
+	/// Paseo's address format, shared with the relay chain and the other Paseo system chains.
+	pub const SS58Prefix: u8 = 42;
 }
 
 /// Calls that are temporarily disabled at the runtime level.

--- a/system-parachains/asset-hub-paseo/src/lib.rs
+++ b/system-parachains/asset-hub-paseo/src/lib.rs
@@ -246,8 +246,7 @@ parameter_types! {
 		})
 		.avg_block_initialization(AVERAGE_ON_INITIALIZE_RATIO)
 		.build_or_panic();
-	/// Paseo's address format, shared with the relay chain and the other Paseo system chains.
-	pub const SS58Prefix: u8 = 42;
+	pub const SS58Prefix: u8 = paseo_runtime_constants::SS58_PREFIX;
 }
 
 /// Calls that are temporarily disabled at the runtime level.

--- a/system-parachains/bridge-hub-paseo/src/lib.rs
+++ b/system-parachains/bridge-hub-paseo/src/lib.rs
@@ -217,7 +217,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: Cow::Borrowed("bridge-hub-paseo"),
 	impl_name: Cow::Borrowed("bridge-hub-paseo"),
 	authoring_version: 1,
-	spec_version: 2_003_001,
+	spec_version: 2_003_002,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 4,
@@ -257,7 +257,7 @@ parameter_types! {
 		})
 		.avg_block_initialization(AVERAGE_ON_INITIALIZE_RATIO)
 		.build_or_panic();
-	pub const SS58Prefix: u8 = 0;
+	pub const SS58Prefix: u8 = paseo_runtime_constants::SS58_PREFIX;
 }
 
 // Configure FRAME pallets to include in runtime.

--- a/system-parachains/bulletin-paseo/src/lib.rs
+++ b/system-parachains/bulletin-paseo/src/lib.rs
@@ -304,7 +304,7 @@ parameter_types! {
 		.build_or_panic();
 	/// 42 (generic Substrate), matching the Paseo relay chain rather than the sibling system
 	/// parachains (which use 0).
-	pub const SS58Prefix: u8 = 42;
+	pub const SS58Prefix: u8 = paseo_runtime_constants::SS58_PREFIX;
 }
 
 // Configure FRAME pallets to include in runtime.

--- a/system-parachains/collectives-paseo/src/lib.rs
+++ b/system-parachains/collectives-paseo/src/lib.rs
@@ -130,7 +130,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: Cow::Borrowed("collectives"),
 	impl_name: Cow::Borrowed("collectives"),
 	authoring_version: 1,
-	spec_version: 2_003_001,
+	spec_version: 2_003_002,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 7,
@@ -202,7 +202,7 @@ impl frame_system::Config for Runtime {
 	type AccountData = pallet_balances::AccountData<Balance>;
 	type SystemWeightInfo = weights::frame_system::WeightInfo<Runtime>;
 	type ExtensionsWeightInfo = weights::frame_system_extensions::WeightInfo<Runtime>;
-	type SS58Prefix = ConstU16<0>;
+	type SS58Prefix = ConstU16<{ paseo_runtime_constants::SS58_PREFIX as u16 }>;
 	type OnSetCode = cumulus_pallet_parachain_system::ParachainSetCode<Self>;
 	type MaxConsumers = frame_support::traits::ConstU32<16>;
 	type SingleBlockMigrations = migrations::SingleBlockMigrations;

--- a/system-parachains/coretime-paseo/src/lib.rs
+++ b/system-parachains/coretime-paseo/src/lib.rs
@@ -167,7 +167,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: Cow::Borrowed("coretime-paseo"),
 	impl_name: Cow::Borrowed("coretime-paseo"),
 	authoring_version: 1,
-	spec_version: 2_003_001,
+	spec_version: 2_003_002,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 0,
@@ -207,7 +207,7 @@ parameter_types! {
 		})
 		.avg_block_initialization(AVERAGE_ON_INITIALIZE_RATIO)
 		.build_or_panic();
-	pub const SS58Prefix: u8 = 0;
+	pub const SS58Prefix: u8 = paseo_runtime_constants::SS58_PREFIX;
 }
 
 /// Filter:

--- a/system-parachains/people-paseo/src/lib.rs
+++ b/system-parachains/people-paseo/src/lib.rs
@@ -176,7 +176,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: Cow::Borrowed("people-paseo"),
 	impl_name: Cow::Borrowed("people-paseo"),
 	authoring_version: 1,
-	spec_version: 2_004_001,
+	spec_version: 2_004_002,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
@@ -220,7 +220,8 @@ parameter_types! {
 		})
 		.avg_block_initialization(AVERAGE_ON_INITIALIZE_RATIO)
 		.build_or_panic();
-	pub const SS58Prefix: u8 = 0;
+	/// Paseo's address format, shared with the relay chain and the other Paseo system chains.
+	pub const SS58Prefix: u8 = 42;
 }
 
 #[derive_impl(frame_system::config_preludes::ParaChainDefaultConfig as frame_system::DefaultConfig)]

--- a/system-parachains/people-paseo/src/lib.rs
+++ b/system-parachains/people-paseo/src/lib.rs
@@ -220,8 +220,7 @@ parameter_types! {
 		})
 		.avg_block_initialization(AVERAGE_ON_INITIALIZE_RATIO)
 		.build_or_panic();
-	/// Paseo's address format, shared with the relay chain and the other Paseo system chains.
-	pub const SS58Prefix: u8 = 42;
+	pub const SS58Prefix: u8 = paseo_runtime_constants::SS58_PREFIX;
 }
 
 #[derive_impl(frame_system::config_preludes::ParaChainDefaultConfig as frame_system::DefaultConfig)]


### PR DESCRIPTION
## Problem

Asset Hub and People inherited `SS58Prefix = 0` from their Polkadot counterparts, while the Paseo relay and Bulletin use `42`. The published chain specs for both chains already advertise `ss58Format: 42`, so **the runtime constant and the chain spec disagree**.

That disagreement is not cosmetic. Tooling that cross-checks `system_properties` against the runtime rejects the chain outright — parity-signer's `interpret_properties`, used by [metadata-portal](https://github.com/paritytech/metadata-portal) to build the Polkadot Vault chain-specs QR, fails with `Base58PrefixMismatch { specs: 42, meta: 0 }`. Verified today against live endpoints:

| Endpoint | spec `ss58Format` | runtime `System::SS58Prefix` | specs fetch |
|---|---|---|---|
| `wss://asset-hub-paseo-rpc.n.dwellir.com` | 42 | 0 | ❌ mismatch |
| `wss://rpc.interweb-it.com/people-paseo` | 42 | 0 | ❌ mismatch |
| `wss://people-paseo.gatotech.network` | 42 | 0 | ❌ mismatch |
| `wss://people-paseo.rotko.net` | 42 | 0 | ❌ mismatch |
| `wss://sys.turboflakes.io/{asset-hub,people}-paseo` | 0 | 0 | ✅ (serves a non-canonical spec) |

This is what blocks publishing Paseo metadata QRs on the metadata portal.

## Change

- `SS58Prefix: u8 = 0` → `42` in `asset-hub-paseo` and `people-paseo`
- `spec_version` `2_004_001` → `2_004_002` for both
- `chain-specs/{asset-hub,people}-paseo-local.json` updated to match, with `properties` encoded as numbers rather than strings

`transaction_version` is intentionally unchanged: `SS58Prefix` is a runtime constant exposed in metadata and does not affect extrinsic encoding.

## Impact

- **Account ids are unchanged.** Only the address format used to *display* them moves from Polkadot-style (`1…`) to Paseo-style (`5…`), matching the relay chain. Balances, proxies, identities and any stored `AccountId` are untouched.
- Wallets and explorers that read the runtime constant (polkadot-js does) switch automatically on enactment.
- **Providers serving a spec with `ss58Format: 0` must redeploy with the canonical spec after enactment**, otherwise the mismatch simply flips direction. Today that is `sys.turboflakes.io` for both chains.

## Verification

- `cargo check -p asset-hub-paseo-runtime -p people-paseo-runtime` — passes (only pre-existing warnings)
- `cargo +nightly-2026-01-10 fmt --all -- --check` — clean
- `taplo format --check --config .config/taplo.toml` — clean (the one error is from a gitignored `substitute-relay/node_modules` path that does not exist in CI)

## Related

- paseo-network/paseo-chain-specs#49 fixes the companion defect: relay and Bulletin specs encode `ss58Format`/`tokenDecimals` as JSON strings, which the same tooling rejects with `Base58PrefixFormatNotSupported`.
- Once this upgrade is enacted and the corrected specs are redeployed by providers, all four live Paseo chains can be added to the upstream metadata portal in one PR.

## Follow-up (not in this PR)

Bridge Hub, Coretime and Collectives runtimes still carry `SS58Prefix = 0`, and several specs under `chain-specs/` (`paseo-local`, `paseo-dev`, `paseo-substitute`, `bulletin-paseo*`) still encode properties as strings. Those chains are not live on the current relay; worth a consistency pass before they are onboarded.