### PR TITLE
feat(people): tune personhood game params for weekly devnet cadence

### DIFF
--- a/system-parachains/people-paseo/src/lib.rs
+++ b/system-parachains/people-paseo/src/lib.rs
@@ -176,7 +176,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: Cow::Borrowed("people-paseo"),
 	impl_name: Cow::Borrowed("people-paseo"),
 	authoring_version: 1,
-	spec_version: 2_004_002,
+	spec_version: 2_004_003,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/system-parachains/people-paseo/src/people.rs
+++ b/system-parachains/people-paseo/src/people.rs
@@ -794,15 +794,22 @@ impl indiv_pallet_game::Config for Runtime {
 	>;
 	type DefaultPlayDeposit = PlayDepositDefault;
 	type TicketSignature = MultiSignature;
-	type MaxGameSchedules = ConstU32<12>;
+	// Weekly game cadence on devnet: 26 lets a single `schedule_games` sudo call queue
+	// ~6 months ahead, so the top-up keeper runs at most twice a year.
+	type MaxGameSchedules = ConstU32<26>;
 	type MaxAttendanceHistoryDepth = ConstU32<12>;
 	type DefaultPhaseDurations = GamePhaseDurations;
 	type AccountSignature = Signature;
 	type PlayerStatementLimit = PlayerStatementLimit;
 	type PeopleVoteWeight = ConstUint<2>;
 	type CandidateVoteWeight = ConstUint<1>;
-	// This is for the testnet, the value must be at least 2 in production.
-	type MinGroupSize = ConstUint<0>;
+	// Production-realistic minimum: a group must hold at least 2 players for mutual
+	// verification to mean anything. Kept at the production floor (not 0) so devnet games
+	// exercise the same grouping behaviour as mainnet. Note: with a low active-player count
+	// this can leave weekly games unable to form a valid group — the DummyDim-recognized
+	// cohort is externally recognized and immune, so only the organic game-onboarding path
+	// is affected.
+	type MinGroupSize = ConstUint<2>;
 	type AirdropAssetId = <Runtime as pallet_assets::Config>::AssetId;
 	type AirdropAssetBalance = Balance;
 	type Airdrop = Airdrop;


### PR DESCRIPTION
## What

Tune two `indiv_pallet_game` config constants on the People (paseo) runtime to
support running **weekly personhood games on devnet**:

- `MaxGameSchedules` **12 → 26** — a single `Game.schedule_games` call can queue
  ~6 months of weekly games, so the scheduling keeper only needs to top up a
  couple of times a year.
- `MinGroupSize` **0 → 2** — groups must hold at least two players for mutual
  verification to mean anything. `0` was the testnet placeholder; `2` is the
  production floor.

## Why

We're standing up a recurring weekly personhood-games cadence on the public
Paseo devnet (People 1004). `MinGroupSize=0` let games "verify" trivially; `2`
exercises the same grouping behaviour as mainnet. The larger schedule queue
keeps the on-chain game calendar filled without frequent operator intervention.

## Notes / review points

- Both are `ConstU32`/`ConstUint` bumps backing `BoundedVec`/threshold reads —
  **increasing** the bounds is decode-compatible, so **no storage migration**.
- After `MinGroupSize=2`, scheduled games must use `max_group_size ≥ 3`
  (`schedule_games` validates `max_group_size > MinGroupSize`).
- Deliberately **not** changing `MaxAttendanceHistoryDepth`: the score-pallet
  absence-grace (decay) window is a `u8` bitmask hard-capped at 8 games, so that
  constant is unrelated to decay memory.
- Weights: existing benchmarks remain conservative; re-bench the game pallet if
  any weight scales with `MaxGameSchedules`.

Draft: opening for review ahead of the devnet runtime upgrade; the game
scheduling/decay config itself is applied via sudo extrinsics (no code change).
