### PR TITLE
bulletin-paseo: fix try-runtime feature propagation

### DIFF
--- a/system-parachains/bulletin-paseo/Cargo.toml
+++ b/system-parachains/bulletin-paseo/Cargo.toml
@@ -239,6 +239,7 @@ try-runtime = [
 	"parachains-common/try-runtime",
 	"polkadot-runtime-common/try-runtime",
 	"sp-runtime/try-runtime",
+	"system-parachains-constants/try-runtime",
 ]
 fast-runtime = []
 


### PR DESCRIPTION
bulletin-paseo does not build with `--features try-runtime`: the feature was never propagated to `system-parachains-constants` (which pulls in `pallet-revive`), so sp-runtime's feature-gated `Checkable` method has no impl (E0046); every sibling system parachain already carries this line. Verified with a full `--locked` try-runtime build; caught by paritytech/polkadot-bulletin-chain CI: https://github.com/paritytech/polkadot-bulletin-chain/actions/runs/30556731803/job/90919192786