### PR TITLE
fix(people): size the block weight for the async-backing cadence

### DIFF
--- a/system-parachains/people-paseo/src/lib.rs
+++ b/system-parachains/people-paseo/src/lib.rs
@@ -55,7 +55,7 @@ use pallet_xcm::{EnsureXcm, IsVoiceOfBody};
 use parachains_common::{
 	message_queue::{NarrowOriginToSibling, ParaIdToSibling},
 	AccountId, Balance, BlockNumber, Hash, Header, Nonce, Signature, AVERAGE_ON_INITIALIZE_RATIO,
-	HOURS, MAXIMUM_BLOCK_WEIGHT, NORMAL_DISPATCH_RATIO,
+	HOURS,
 };
 use polkadot_runtime_common::{BlockHashCount, SlowAdjustingFeeUpdate};
 use sp_api::impl_runtime_apis;
@@ -73,6 +73,12 @@ pub use sp_runtime::{MultiAddress, Perbill, Permill};
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
+// This runtime produces 2-second blocks (`elastic_scaling`: a 6s relay slot at
+// `BLOCK_PROCESSING_VELOCITY = 3`), which is the async-backing block cadence. Its block *weight*
+// must be sized for that cadence, and `asset-hub-paseo` — configured with the same
+// `SLOT_DURATION` and the same `elastic_scaling` parameters — already imports these two from
+// here. See the PR description.
+use system_parachains_constants::async_backing::{MAXIMUM_BLOCK_WEIGHT, NORMAL_DISPATCH_RATIO};
 use system_parachains_constants::paseo::{
 	consensus::{
 		elastic_scaling::{
@@ -176,7 +182,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: Cow::Borrowed("people-paseo"),
 	impl_name: Cow::Borrowed("people-paseo"),
 	authoring_version: 1,
-	spec_version: 2_004_003,
+	spec_version: 2_004_004,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/system-parachains/people-paseo/src/lib.rs
+++ b/system-parachains/people-paseo/src/lib.rs
@@ -78,16 +78,18 @@ use sp_version::RuntimeVersion;
 // must be sized for that cadence, and `asset-hub-paseo` — configured with the same
 // `SLOT_DURATION` and the same `elastic_scaling` parameters — already imports these two from
 // here. See the PR description.
-use system_parachains_constants::async_backing::{MAXIMUM_BLOCK_WEIGHT, NORMAL_DISPATCH_RATIO};
-use system_parachains_constants::paseo::{
-	consensus::{
-		elastic_scaling::{
-			BLOCK_PROCESSING_VELOCITY, RELAY_PARENT_OFFSET, UNINCLUDED_SEGMENT_CAPACITY,
+use system_parachains_constants::{
+	async_backing::{MAXIMUM_BLOCK_WEIGHT, NORMAL_DISPATCH_RATIO},
+	paseo::{
+		consensus::{
+			elastic_scaling::{
+				BLOCK_PROCESSING_VELOCITY, RELAY_PARENT_OFFSET, UNINCLUDED_SEGMENT_CAPACITY,
+			},
+			RELAY_CHAIN_SLOT_DURATION_MILLIS,
 		},
-		RELAY_CHAIN_SLOT_DURATION_MILLIS,
+		currency::*,
+		fee::WeightToFee as PasWeightToFee,
 	},
-	currency::*,
-	fee::WeightToFee as PasWeightToFee,
 };
 use weights::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight};
 use xcm::{


### PR DESCRIPTION
`people-paseo` produces **2-second blocks** — `elastic_scaling` at `BLOCK_PROCESSING_VELOCITY = 3` over a 6s relay slot — but takes `MAXIMUM_BLOCK_WEIGHT` and `NORMAL_DISPATCH_RATIO` from `parachains_common`, which are the *pre*-async-backing values: **0.5s of compute at 75%**.

`asset-hub-paseo` is configured with the same `SLOT_DURATION` and the same `elastic_scaling` consensus parameters, and already imports both constants from `system_parachains_constants::async_backing` — **2s at 85%**.

So the two system parachains agree on how often they produce a block and disagree by 4x on how much work one may contain.

| | consensus | block weight source | `MAXIMUM_BLOCK_WEIGHT` | `NORMAL_DISPATCH_RATIO` |
|---|---|---|---|---|
| `asset-hub-paseo` | `elastic_scaling`, velocity 3 | `system_parachains_constants::async_backing` | 2s | 85% |
| `people-paseo` | `elastic_scaling`, velocity 3 | `parachains_common` | **0.5s** | **75%** |

### Every comparable runtime already does this

| runtime | block weight source |
|---|---|
| `asset-hub-paseo` (this repo) | `system_parachains_constants::async_backing` |
| `people-polkadot` (polkadot-fellows/runtimes, `kiz-release-2.5`) | `async_backing::{AVERAGE_ON_INITIALIZE_RATIO, MAXIMUM_BLOCK_WEIGHT, NORMAL_DISPATCH_RATIO}` |
| `next-people-paseo` (individuality-community v0.3.1) | its own async-backing constants, 2s / 85% |
| **`people-paseo` (this repo)** | **`parachains_common` — 0.5s / 75%** |

`people-paseo` is the only People-class runtime in the set that is not sized for the async-backing cadence.

This aligns People with Asset Hub. **Only those two constants move.** `HOURS`, `AVERAGE_ON_INITIALIZE_RATIO` and every time-denominated constant are left exactly as they are — People's `HOURS` and Asset Hub's differ, and that is a separate question this PR deliberately does not touch.

## How it was found

Testing the individuality v0.3.1 port. That version's `game` pallet asserts in `integrity_test` that a worst-case `sign_up` — one registering into `MAX_GAME_AIRDROPS = 16` airdrop events — fits half of `Normal.max_extrinsic`. On the current values it does not: **265.3G ref_time against a 174.9G budget**, because each airdrop registration costs a ring-VRF verification at ~16.2G.

That is not a weights artifact. Upstream's generated coefficient (`16_207_107_100`) and the in-crate reference (`16_244_697_534`) agree to 0.2%, so regenerating weights would not move it.

**The assertion is what surfaced this, but the mismatch predates it and is independent of it** — it is present on `main` today, with no individuality change in sight.

## Verification

`people-paseo-runtime` builds and its full test suite passes on this branch: **11 passed, 0 failed**.

Applied on top of the individuality v0.3.1 port, People goes from 17 passed / 1 failed to **18 passed / 0 failed**, the one failure being the `sign_up` assertion above.

## Note

The `spec_version` bump collides with any other in-flight People release; whichever lands second should rebase it.

Raised as its own PR rather than folded into the individuality work, because quadrupling a live system parachain's block capacity is a network decision that deserves to be judged on its own merits.
