### PR TITLE
individuality v0.3.1: the coinage and ring-commitment storage migrations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10897,6 +10897,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-executive",
  "frame-metadata-hash-extension",
+ "frame-remote-externalities",
  "frame-support",
  "frame-system",
  "frame-system-benchmarking",
@@ -10972,6 +10973,7 @@ dependencies = [
  "sp-session",
  "sp-statement-store 26.0.0",
  "sp-storage",
+ "sp-tracing",
  "sp-transaction-pool",
  "sp-version",
  "staging-parachain-info",
@@ -10980,6 +10982,7 @@ dependencies = [
  "staging-xcm-executor",
  "substrate-wasm-builder",
  "system-parachains-constants 2.3.1",
+ "tokio",
  "verifiable",
  "xcm-runtime-apis",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -193,6 +193,7 @@ enumflags2 = { version = "0.7.7" }
 frame-benchmarking = { version = "48.0.0", default-features = false }
 frame-election-provider-support = { version = "47.0.0", default-features = false }
 frame-executive = { version = "47.0.0", default-features = false }
+frame-remote-externalities = { version = "0.59.0" }
 frame-support = { version = "47.0.0", default-features = false }
 frame-system = { version = "47.0.0", default-features = false }
 frame-system-benchmarking = { version = "48.0.0", default-features = false }

--- a/pallets/members-subscriber/src/migration.rs
+++ b/pallets/members-subscriber/src/migration.rs
@@ -537,8 +537,36 @@ pub mod v1 {
 			}
 
 			// 3. No entry is left at the pre-v0.3 key layout.
+			//
+			// This MUST discriminate on the raw key length, not by decoding. The old double map
+			// and the new NMap share an item prefix, and the new key is the old key with a
+			// 12-byte `Twox64Concat(Generation)` segment spliced in FRONT:
+			//
+			//   old: prefix(32) + Identifier(48) + RingIndex(20)              = 100 bytes
+			//   new: prefix(32) + Generation(12) + Identifier(48) + RingIndex(20) = 112 bytes
+			//
+			// So `old::RingRoots::<T>::iter_keys()` happily decodes a NEW key as an old one --
+			// the trailing 12 bytes are simply ignored -- and reports every migrated entry as a
+			// phantom leftover. That is the same trailing-bytes trap this migration exists to
+			// defuse, and it made `post_upgrade` fail on a correct migration.
+			let ring_roots_prefix = frame_support::storage::storage_prefix(
+				<Pallet<T> as frame_support::traits::PalletInfoAccess>::name().as_bytes(),
+				b"RingRoots",
+			);
+			const OLD_RING_ROOTS_KEY_LEN: usize = 32 + 48 + 20;
+			let mut stale = 0usize;
+			let mut cursor = ring_roots_prefix.to_vec();
+			while let Some(next) = sp_io::storage::next_key(&cursor) {
+				if !next.starts_with(&ring_roots_prefix) {
+					break;
+				}
+				if next.len() == OLD_RING_ROOTS_KEY_LEN {
+					stale += 1;
+				}
+				cursor = next;
+			}
 			ensure!(
-				old::RingRoots::<T>::iter_keys().next().is_none(),
+				stale == 0,
 				"members-subscriber: an entry remains at the pre-v0.3 RingRoots key layout"
 			);
 			// ...and the new map holds exactly what was captured, nothing invented.

--- a/system-parachains/people-paseo/Cargo.toml
+++ b/system-parachains/people-paseo/Cargo.toml
@@ -119,7 +119,10 @@ parachains-common = { workspace = true }
 system-parachains-constants = { workspace = true }
 
 [dev-dependencies]
+frame-remote-externalities = { workspace = true }
 parachains-runtimes-test-utils = { workspace = true }
+sp-tracing = { workspace = true, default-features = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [build-dependencies]
 substrate-wasm-builder = { optional = true, workspace = true }

--- a/system-parachains/people-paseo/src/migrations/coinage.rs
+++ b/system-parachains/people-paseo/src/migrations/coinage.rs
@@ -651,3 +651,265 @@ impl MigrateCoinageToInstances {
 		Ok(())
 	}
 }
+
+/// The 16 `pallet-members` storage items keyed by `Identifier`, all `Identity`-hashed.
+///
+/// `Identity` means the 32 identifier bytes appear verbatim in the key, so relocating a collection
+/// is a pure byte splice — `dest = item_prefix ++ new_id ++ tail` — with no value ever decoded.
+/// `IdentifiersOf` is deliberately absent: it is keyed by *owner*, not identifier, and is handled
+/// separately.
+const MEMBERS_ITEMS: [&str; 16] = [
+	"Collections",
+	"SuspendedCollections",
+	"Root",
+	"OldRoots",
+	"CurrentRingIndex",
+	"OnboardingSize",
+	"RingKeys",
+	"RingKeysStatus",
+	"PendingSuspensions",
+	"ActiveMembers",
+	"Members",
+	"RingsState",
+	"StaleRings",
+	"QueuePageIndices",
+	"OnboardingQueue",
+	"RingDeletionQueue",
+];
+
+/// Baseline identifier: `b"coinage/recycler" ++ [denomination] ++ [0u8; 15]`.
+fn legacy_recycler_identifier(denomination: i8) -> [u8; 32] {
+	let mut id = [0u8; 32];
+	id[0..16].copy_from_slice(&indiv_pallet_coinage::RECYCLER_COLLECTION_PREFIX);
+	id[16] = denomination as u8;
+	id
+}
+
+/// v0.3.1 identifier: the instance id is spliced in at `[16..20]` and the denomination moves to
+/// `[20]`. Even at instance 0 this differs from the baseline for every denomination but zero.
+fn instanced_recycler_identifier(denomination: i8) -> [u8; 32] {
+	let mut id = [0u8; 32];
+	id[0..16].copy_from_slice(&indiv_pallet_coinage::RECYCLER_COLLECTION_PREFIX);
+	id[16..20].copy_from_slice(&LEGACY_INSTANCE_ID.to_le_bytes());
+	id[20] = denomination as u8;
+	id
+}
+
+/// `twox128("Members") ++ twox128(item) ++ identifier`.
+fn members_item_prefix(item: &str, identifier: &[u8; 32]) -> alloc::vec::Vec<u8> {
+	let mut key = alloc::vec::Vec::with_capacity(64 + 32);
+	key.extend_from_slice(&sp_io::hashing::twox_128(b"Members"));
+	key.extend_from_slice(&sp_io::hashing::twox_128(item.as_bytes()));
+	key.extend_from_slice(identifier);
+	key
+}
+
+/// Where [`RelocateCoinageRecyclerCollections`] has got to.
+#[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Clone, PartialEq, Eq, Debug)]
+pub enum Relocation {
+	/// Splicing raw keys, item by item, denomination by denomination.
+	Keys {
+		/// Index into [`MEMBERS_ITEMS`].
+		item: u8,
+		/// The denomination being relocated.
+		denomination: i8,
+		/// The raw key last spliced, or `None` to start this prefix.
+		last: Option<BoundedVec<u8, ConstU32<MAX_CURSOR_KEY>>>,
+	},
+	/// Rewriting each relocated collection's recorded owner.
+	Owners { denomination: i8 },
+	/// Re-pointing the owner index.
+	Index,
+}
+
+/// Unit C — relocate the 15 live recycler collections inside `pallet-members`.
+///
+/// v0.3.1 changed the identifier derivation from `id[16] = denomination` to
+/// `id[16..20] = instance_id; id[20] = denomination`, so every existing recycler ring sits at an
+/// address the new code never looks at. Unmigrated, loading or unloading recreates empty
+/// collections beside the old ones and the existing member rows are stranded.
+///
+/// `pallet-members` hashes `Identifier` with `Identity` in all 16 of the items below, so the
+/// identifier bytes appear verbatim in the key and relocation is a pure byte splice — no value is
+/// ever decoded, which is what makes this cheaper per row than unit B despite being larger.
+///
+/// The two things that are *not* prefix-movable are handled in their own phases: the owner
+/// recorded inside `CollectionInfo`, and `IdentifiersOf`, which is keyed by owner rather than by
+/// identifier.
+pub struct RelocateCoinageRecyclerCollections;
+
+impl SteppedMigration for RelocateCoinageRecyclerCollections {
+	type Cursor = Relocation;
+	type Identifier = MigrationId<32>;
+
+	fn id() -> Self::Identifier {
+		MigrationId {
+			pallet_id: *b"paseo-coinage-relocate-recycler-",
+			version_from: 0,
+			version_to: 1,
+		}
+	}
+
+	fn step(
+		cursor: Option<Self::Cursor>,
+		meter: &mut WeightMeter,
+	) -> Result<Option<Self::Cursor>, SteppedMigrationError> {
+		let required = per_entry_weight();
+		if meter.remaining().any_lt(required) {
+			return Err(SteppedMigrationError::InsufficientWeight { required });
+		}
+
+		let mut state =
+			cursor.unwrap_or(Relocation::Keys { item: 0, denomination: i8::MIN, last: None });
+
+		loop {
+			if meter.try_consume(required).is_err() {
+				return Ok(Some(state));
+			}
+
+			state = match state {
+				Relocation::Keys { item, denomination, last } =>
+					step_relocate_keys(item, denomination, last),
+				Relocation::Owners { denomination } => step_relocate_owner(denomination),
+				Relocation::Index =>
+					return {
+						relocate_identifier_index();
+						Ok(None)
+					},
+			};
+		}
+	}
+}
+
+/// Advance the (item, denomination) walk, wrapping denomination into the next item.
+fn advance(item: u8, denomination: i8) -> Relocation {
+	match denomination.checked_add(1) {
+		Some(next) => Relocation::Keys { item, denomination: next, last: None },
+		// Denominations exhausted for this item; move to the next one.
+		None => match item.checked_add(1) {
+			Some(next) if (next as usize) < MEMBERS_ITEMS.len() =>
+				Relocation::Keys { item: next, denomination: i8::MIN, last: None },
+			_ => Relocation::Owners { denomination: i8::MIN },
+		},
+	}
+}
+
+/// Splice one raw key from a collection's legacy prefix to its instanced prefix.
+fn step_relocate_keys(
+	item: u8,
+	denomination: i8,
+	last: Option<BoundedVec<u8, ConstU32<MAX_CURSOR_KEY>>>,
+) -> Relocation {
+	let Some(name) = MEMBERS_ITEMS.get(item as usize) else {
+		return Relocation::Owners { denomination: i8::MIN };
+	};
+
+	// Only denominations this chain actually has a collection for. Derived from the double map
+	// unit A seeded, so it survives unit B dropping the legacy markers.
+	if !RecyclerCollectionCreated::<Runtime>::contains_key(LEGACY_INSTANCE_ID, denomination) {
+		return advance(item, denomination);
+	}
+
+	let src = members_item_prefix(name, &legacy_recycler_identifier(denomination));
+	let dst = members_item_prefix(name, &instanced_recycler_identifier(denomination));
+
+	let from = last.map(|k| k.to_vec()).unwrap_or_else(|| src.clone());
+	let Some(key) = sp_io::storage::next_key(&from) else {
+		return advance(item, denomination);
+	};
+	if !key.starts_with(&src) {
+		return advance(item, denomination);
+	}
+
+	// Pure splice: the identifier occupies a fixed 32-byte slot, so everything after the source
+	// prefix is the untouched remainder of the key.
+	let mut moved = dst;
+	moved.extend_from_slice(&key[src.len()..]);
+	if let Some(value) = sp_io::storage::get(&key) {
+		sp_io::storage::set(&moved, &value);
+		sp_io::storage::clear(&key);
+	}
+
+	match bound_key(key) {
+		Some(k) => Relocation::Keys { item, denomination, last: Some(k) },
+		None => advance(item, denomination),
+	}
+}
+
+/// Rewrite one relocated collection's recorded owner from the pallet account to the
+/// instance-scoped one, matching `Coinage::recycler_collection_owner(0)`.
+fn step_relocate_owner(denomination: i8) -> Relocation {
+	if !RecyclerCollectionCreated::<Runtime>::contains_key(LEGACY_INSTANCE_ID, denomination) {
+		return match denomination.checked_add(1) {
+			Some(next) => Relocation::Owners { denomination: next },
+			None => Relocation::Index,
+		};
+	}
+
+	let id = instanced_recycler_identifier(denomination);
+	indiv_pallet_members::Collections::<Runtime>::mutate(id, |maybe| {
+		if let Some(info) = maybe {
+			info.owner =
+				indiv_pallet_members::CollectionOwner::External(indiv_pallet_coinage::Pallet::<
+					Runtime,
+				>::recycler_collection_owner(
+					LEGACY_INSTANCE_ID
+				));
+		}
+	});
+
+	match denomination.checked_add(1) {
+		Some(next) => Relocation::Owners { denomination: next },
+		None => Relocation::Index,
+	}
+}
+
+/// Move the relocated identifiers from the pallet-account owner index to the instance-scoped one,
+/// leaving the paid-token collections — which did **not** move — where they are.
+///
+/// 🔴 This is the one place unit C can fail on a bound: both resulting lists are
+/// `BoundedVec<_, MaxCollections>`. Overflow is logged and the entry left untouched rather than
+/// panicking, because People freezes on a failed migration.
+fn relocate_identifier_index() {
+	use indiv_pallet_members::{CollectionOwner, IdentifiersOf};
+
+	let old_owner = CollectionOwner::External(xcm::v5::Location::new(
+		0,
+		[xcm::v5::Junction::PalletInstance(
+			<indiv_pallet_coinage::Pallet<Runtime> as frame_support::traits::PalletInfoAccess>::index() as u8,
+		)],
+	));
+	let new_owner = CollectionOwner::External(
+		indiv_pallet_coinage::Pallet::<Runtime>::recycler_collection_owner(LEGACY_INSTANCE_ID),
+	);
+
+	let relocated: alloc::vec::Vec<[u8; 32]> =
+		RecyclerCollectionCreated::<Runtime>::iter_key_prefix(LEGACY_INSTANCE_ID)
+			.map(instanced_recycler_identifier)
+			.collect();
+	let legacy: alloc::vec::Vec<[u8; 32]> =
+		RecyclerCollectionCreated::<Runtime>::iter_key_prefix(LEGACY_INSTANCE_ID)
+			.map(legacy_recycler_identifier)
+			.collect();
+
+	IdentifiersOf::<Runtime>::mutate(&old_owner, |maybe| {
+		if let Some(list) = maybe {
+			list.retain(|id| !legacy.contains(id));
+		}
+	});
+
+	IdentifiersOf::<Runtime>::mutate(&new_owner, |maybe| {
+		let list = maybe.get_or_insert_with(Default::default);
+		for id in &relocated {
+			if list.contains(id) {
+				continue;
+			}
+			if list.try_push(*id).is_err() {
+				log::error!(
+					target: "runtime::coinage-migration",
+					"IdentifiersOf overflow for the instanced owner; collection left unindexed",
+				);
+			}
+		}
+	});
+}

--- a/system-parachains/people-paseo/src/migrations/coinage.rs
+++ b/system-parachains/people-paseo/src/migrations/coinage.rs
@@ -1,0 +1,267 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! PASEO-LOCAL storage migrations for `indiv-pallet-coinage`.
+//!
+//! # Why these exist and upstream ships none
+//!
+//! individuality v0.3.1 rewrites `coinage` into a multi-instance registry. Upstream needs no
+//! migration for it because its `next-*` runtimes are launched from genesis presets and never
+//! carry pre-v0.3 state — verified: `next-people-paseo` is at spec `3000000` and its
+//! `Coinage::UnderlyingAssetId` reads `None`. **Paseo is the only chain upgrading into v0.3.x
+//! while holding live coinage state**, so the migration set is Paseo's alone.
+//!
+//! # These live in the runtime, not in the pallet
+//!
+//! The design this follows proposed adding a `STORAGE_VERSION` to the vendored `coinage` crate so
+//! the units could be wrapped in `VersionedMigration`. That is avoided here: every type these
+//! touch is `pub` at the coinage crate root, so the migrations sit in the runtime and the vendored
+//! pallet stays **byte-identical to the v0.3.1 tag**. Guarding is by other means —
+//! [`SeedCoinageInstanceZero`] is idempotent on its own writes, and the multi-block units are
+//! tracked by `pallet_migrations` against their `id()`.
+//!
+//! # 🔴 Failure behaviour on this chain
+//!
+//! People binds `FailedMigrationHandler = FreezeChainOnFailedMigration` (`lib.rs`), where Asset Hub
+//! binds `ForceUnstuckOnFailedMigration`. **A panic in any of these freezes the People chain.**
+//! Everything here is written to be panic-free: saturating arithmetic, no `expect`, no unbounded
+//! allocation, and no assumption that a decode succeeds.
+//!
+//! # Live state these were designed against
+//!
+//! Read read-only at People block **6,457,055**. Counts are recorded for orientation only —
+//! **nothing here hardcodes them**, and that matters: `RecyclersCoinToRecycler` was 5,711 when the
+//! design was written and is 5,735 now.
+//!
+//! | item | keys |
+//! | --- | --- |
+//! | `CoinsByOwner` | 816 |
+//! | `LockedCoins` | 17 |
+//! | `RecyclersCoinToRecycler` | 5,735 |
+//! | `RecyclersUnloaded` | 385 (the anti-replay set) |
+//! | `RecyclerCollectionCreated` | 15 (denominations 0..=14) |
+//! | `RecyclersLastRemovedRingIndex`, `RecyclersDusting`, `PaidUnloadTokenMembers` | 0 |
+//! | `Instances` | 0 — nothing seeded yet |
+
+use crate::{Runtime, Weight};
+use frame_support::{
+	pallet_prelude::*,
+	traits::{Get, OnRuntimeUpgrade},
+};
+use indiv_pallet_coinage::{
+	AssetToInstance, Config as CoinageConfig, FungiblesAssetIdOf, InstanceMode, InstanceRecord,
+	Instances, NextInstanceId, RecyclerCollectionCreated,
+};
+
+/// The asset amount of a denomination-zero coin for the pre-existing instance.
+///
+/// Inherited verbatim from the baseline runtime's `Config::UnderlyingAssetUnit`
+/// (`ConstUint<{ 10u128.pow(4) }>` — "$0.01, the unit is 10^6"), which individuality v0.3.1 moved
+/// out of `Config` and into [`InstanceRecord::asset_unit`]. Seeding anything else would silently
+/// reprice every coin already on the chain.
+pub const LEGACY_ASSET_UNIT: u128 = 10u128.pow(4);
+
+/// The instance id the pre-existing coin population is adopted into.
+pub const LEGACY_INSTANCE_ID: u32 = 0;
+
+/// Storage as the **currently deployed** runtime declares it. Only items whose declaration changed
+/// or was removed need an alias; anything unchanged is read through the live types.
+pub mod old {
+	use super::*;
+	use indiv_pallet_coinage::Pallet;
+
+	/// Removed in v0.3.1. It is the seed input for [`InstanceRecord::asset_id`], so it must be
+	/// read before it is killed.
+	#[frame_support::storage_alias]
+	pub type UnderlyingAssetId<T: CoinageConfig> =
+		StorageValue<Pallet<T>, FungiblesAssetIdOf<T>, OptionQuery>;
+
+	/// Removed in v0.3.1; a stale marker with no successor.
+	#[frame_support::storage_alias]
+	pub type InitializePalletAccount<T: CoinageConfig> = StorageValue<Pallet<T>, (), OptionQuery>;
+
+	/// Baseline shape: a single map keyed by denomination alone. v0.3.1 makes it a double map
+	/// keyed `(InstanceId, Denomination)` **at the same storage prefix**, so the old keys land
+	/// inside the new map's keyspace and must be removed, not merely superseded.
+	#[frame_support::storage_alias]
+	pub type RecyclerCollectionCreated<T: CoinageConfig> =
+		StorageMap<Pallet<T>, Twox64Concat, i8, (), OptionQuery>;
+}
+
+/// Unit A — adopt the pre-existing coin population into instance 0.
+///
+/// Single-block: it writes a bounded, live-state-independent number of keys (one instance record,
+/// one counter, one asset index entry, and one per existing denomination — 15 today).
+///
+/// **Must run before the multi-block units.** Both of those phrase their invariants against
+/// `Instances[0]` existing, and every coin operation reads it, so a partially-migrated chain with
+/// no instance record would reject every call.
+///
+/// Idempotent: re-running is a no-op once `Instances[0]` exists, so no pallet storage version is
+/// needed to guard it.
+pub struct SeedCoinageInstanceZero;
+
+impl OnRuntimeUpgrade for SeedCoinageInstanceZero {
+	fn on_runtime_upgrade() -> Weight {
+		let mut reads = 1u64;
+		let mut writes = 0u64;
+
+		if Instances::<Runtime>::contains_key(LEGACY_INSTANCE_ID) {
+			log::info!(
+				target: "runtime::coinage-migration",
+				"instance {LEGACY_INSTANCE_ID} already seeded; skipping",
+			);
+			return <Runtime as frame_system::Config>::DbWeight::get().reads(reads);
+		}
+
+		reads = reads.saturating_add(1);
+		let Some(asset_id) = old::UnderlyingAssetId::<Runtime>::get() else {
+			// Nothing to adopt: a chain that never set the underlying asset has no coins either.
+			// Not an error, and deliberately not a panic — People freezes on a failed migration.
+			log::warn!(
+				target: "runtime::coinage-migration",
+				"no UnderlyingAssetId set; nothing to adopt into an instance",
+			);
+			return <Runtime as frame_system::Config>::DbWeight::get().reads(reads);
+		};
+
+		Instances::<Runtime>::insert(
+			LEGACY_INSTANCE_ID,
+			InstanceRecord::<Runtime> {
+				asset_id: asset_id.clone(),
+				asset_unit: LEGACY_ASSET_UNIT,
+				// `Sufficient` is the shape that reproduces baseline behaviour: no pot, loads take
+				// no deposit, and no `InstanceCreationDeposit` ticket to release. `Sponsored`
+				// would demand a funded pot account that does not exist on this chain.
+				mode: InstanceMode::Sufficient,
+				current_load_deposit: None,
+				old_load_deposit: None,
+				creator: None,
+			},
+		);
+		NextInstanceId::<Runtime>::put(LEGACY_INSTANCE_ID.saturating_add(1));
+		AssetToInstance::<Runtime>::insert(&asset_id, LEGACY_INSTANCE_ID, ());
+		writes = writes.saturating_add(3);
+
+		// Re-key the per-denomination collection markers into the double map. The old keys are
+		// dropped by the multi-block unit, which owns every removal from this prefix.
+		let mut denominations = 0u32;
+		for denomination in old::RecyclerCollectionCreated::<Runtime>::iter_keys() {
+			RecyclerCollectionCreated::<Runtime>::insert(LEGACY_INSTANCE_ID, denomination, ());
+			denominations = denominations.saturating_add(1);
+		}
+		reads = reads.saturating_add(denominations.into());
+		writes = writes.saturating_add(denominations.into());
+
+		// Both are removed in v0.3.1 and have no successor.
+		old::UnderlyingAssetId::<Runtime>::kill();
+		old::InitializePalletAccount::<Runtime>::kill();
+		writes = writes.saturating_add(2);
+
+		log::info!(
+			target: "runtime::coinage-migration",
+			"seeded instance {LEGACY_INSTANCE_ID} (asset_unit {LEGACY_ASSET_UNIT}) and re-keyed \
+			 {denominations} recycler collection marker(s)",
+		);
+
+		<Runtime as frame_system::Config>::DbWeight::get().reads_writes(reads, writes)
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade() -> Result<alloc::vec::Vec<u8>, sp_runtime::TryRuntimeError> {
+		use codec::Encode;
+
+		ensure!(
+			Instances::<Runtime>::iter().next().is_none(),
+			"coinage: instances already exist; this runtime has been migrated already",
+		);
+		let asset_id = old::UnderlyingAssetId::<Runtime>::get();
+		ensure!(asset_id.is_some(), "coinage: no UnderlyingAssetId to seed instance 0 from",);
+
+		let denominations: alloc::vec::Vec<i8> =
+			old::RecyclerCollectionCreated::<Runtime>::iter_keys().collect();
+		log::info!(
+			target: "runtime::coinage-migration",
+			"pre_upgrade: seeding from asset {asset_id:?}; {} denomination(s) to re-key",
+			denominations.len(),
+		);
+		Ok((asset_id, denominations).encode())
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade(state: alloc::vec::Vec<u8>) -> Result<(), sp_runtime::TryRuntimeError> {
+		use codec::Decode;
+
+		let (expected_asset, expected_denominations): (
+			Option<FungiblesAssetIdOf<Runtime>>,
+			alloc::vec::Vec<i8>,
+		) = Decode::decode(&mut &state[..])
+			.map_err(|_| "coinage: could not decode the pre_upgrade capture")?;
+		let expected_asset =
+			expected_asset.ok_or("coinage: pre_upgrade captured no underlying asset")?;
+
+		let record = Instances::<Runtime>::get(LEGACY_INSTANCE_ID)
+			.ok_or("coinage: instance 0 was not seeded")?;
+		ensure!(record.asset_id == expected_asset, "coinage: instance 0 has the wrong asset");
+		ensure!(
+			record.asset_unit == LEGACY_ASSET_UNIT,
+			"coinage: instance 0 would reprice every existing coin",
+		);
+		ensure!(record.mode == InstanceMode::Sufficient, "coinage: instance 0 is not Sufficient");
+		ensure!(
+			record.creator.is_none() &&
+				record.current_load_deposit.is_none() &&
+				record.old_load_deposit.is_none(),
+			"coinage: instance 0 must carry no deposit ledger",
+		);
+		ensure!(
+			NextInstanceId::<Runtime>::get() == LEGACY_INSTANCE_ID.saturating_add(1),
+			"coinage: NextInstanceId was not advanced past the seeded instance",
+		);
+		ensure!(
+			AssetToInstance::<Runtime>::contains_key(&expected_asset, LEGACY_INSTANCE_ID),
+			"coinage: the asset is not indexed to instance 0",
+		);
+
+		// Every denomination that existed must be reachable under the new key shape. Compared
+		// against the pre_upgrade capture, never against a documented count: the live figures
+		// have already drifted once between the design and now.
+		for denomination in &expected_denominations {
+			ensure!(
+				RecyclerCollectionCreated::<Runtime>::contains_key(
+					LEGACY_INSTANCE_ID,
+					denomination
+				),
+				"coinage: a recycler collection marker was not re-keyed",
+			);
+		}
+
+		ensure!(
+			old::UnderlyingAssetId::<Runtime>::get().is_none(),
+			"coinage: the removed UnderlyingAssetId key was left behind",
+		);
+		ensure!(
+			old::InitializePalletAccount::<Runtime>::get().is_none(),
+			"coinage: the removed InitializePalletAccount key was left behind",
+		);
+
+		log::info!(
+			target: "runtime::coinage-migration",
+			"post_upgrade: instance 0 seeded and {} denomination(s) verified",
+			expected_denominations.len(),
+		);
+		Ok(())
+	}
+}

--- a/system-parachains/people-paseo/src/migrations/coinage.rs
+++ b/system-parachains/people-paseo/src/migrations/coinage.rs
@@ -57,13 +57,17 @@
 
 use crate::{Runtime, Weight};
 use frame_support::{
+	migrations::{MigrationId, SteppedMigration, SteppedMigrationError},
 	pallet_prelude::*,
-	traits::{Get, OnRuntimeUpgrade},
+	traits::OnRuntimeUpgrade,
+	weights::WeightMeter,
 };
 use indiv_pallet_coinage::{
-	AssetToInstance, Config as CoinageConfig, FungiblesAssetIdOf, InstanceMode, InstanceRecord,
-	Instances, NextInstanceId, RecyclerCollectionCreated,
+	AliasState, AssetToInstance, Coin, Config as CoinageConfig, FungiblesAssetIdOf, InstanceMode,
+	InstanceRecord, Instances, LockInfo, MemberOf, NextInstanceId, RecyclerAliasStates,
+	RecyclerCollectionCreated, RecyclersCoinToRecycler,
 };
+use indiv_support::traits::{Alias, RingIndex};
 
 /// The asset amount of a denomination-zero coin for the pre-existing instance.
 ///
@@ -98,6 +102,54 @@ pub mod old {
 	#[frame_support::storage_alias]
 	pub type RecyclerCollectionCreated<T: CoinageConfig> =
 		StorageMap<Pallet<T>, Twox64Concat, i8, (), OptionQuery>;
+
+	/// Baseline `Coin`: `{ value: i8, age: u16 }`, 3 bytes. v0.3.1 prepends `instance_id: u32`,
+	/// making it 7. The old bytes decode to nothing under the new type, and `OptionQuery` turns
+	/// that into "no coin" — which is why 816 balances would read as zero unmigrated.
+	#[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Clone, PartialEq, Eq, Debug)]
+	pub struct OldCoin {
+		pub value: i8,
+		pub age: u16,
+	}
+
+	#[frame_support::storage_alias]
+	pub type CoinsByOwner<T: CoinageConfig> = StorageMap<
+		Pallet<T>,
+		Twox64Concat,
+		<T as frame_system::Config>::AccountId,
+		OldCoin,
+		OptionQuery,
+	>;
+
+	/// Baseline `LockedCoin` and v0.3.1 `LockInfo` are field-identical
+	/// (`{ reason: LockReason, until: u64 }`, and `LockReason` is unchanged), so the value bytes
+	/// carry over verbatim and this alias reads them straight into the live type. Only the hasher
+	/// moves.
+	#[frame_support::storage_alias]
+	pub type LockedCoins<T: CoinageConfig> = StorageMap<
+		Pallet<T>,
+		Twox64Concat,
+		<T as frame_system::Config>::AccountId,
+		LockInfo,
+		OptionQuery,
+	>;
+
+	/// Baseline value is a bare `CoinValue` (1 byte); v0.3.1 widens it to
+	/// `(InstanceId, Denomination)` (5 bytes).
+	#[frame_support::storage_alias]
+	pub type RecyclersCoinToRecycler<T: CoinageConfig> =
+		StorageMap<Pallet<T>, Twox64Concat, MemberOf<T>, i8, OptionQuery>;
+
+	/// 🔴 The anti-replay set. Removed in v0.3.1 with no successor; its role is taken by
+	/// `RecyclerAliasStates`, which starts empty. Left unmigrated, a previously-consumed alias
+	/// reads as available and an old ring-VRF proof can unload the same position twice.
+	#[frame_support::storage_alias]
+	pub type RecyclersUnloaded<T: CoinageConfig> = StorageNMap<
+		Pallet<T>,
+		(NMapKey<Twox64Concat, i8>, NMapKey<Twox64Concat, RingIndex>, NMapKey<Twox64Concat, Alias>),
+		(),
+		OptionQuery,
+	>;
 }
 
 /// Unit A — adopt the pre-existing coin population into instance 0.
@@ -261,6 +313,340 @@ impl OnRuntimeUpgrade for SeedCoinageInstanceZero {
 			target: "runtime::coinage-migration",
 			"post_upgrade: instance 0 seeded and {} denomination(s) verified",
 			expected_denominations.len(),
+		);
+		Ok(())
+	}
+}
+
+/// How much of one entry's work a single step charges: read the old key, write the new one, kill
+/// the old one. Deliberately generous — PoV, not ref-time, is the binding constraint here, and the
+/// meter stops us long before the block does.
+fn per_entry_weight() -> Weight {
+	<Runtime as frame_system::Config>::DbWeight::get().reads_writes(1, 2)
+}
+
+/// The longest raw storage key any phase resumes from. The widest is the `RecyclersUnloaded`
+/// n-map: 32-byte item prefix + three `Twox64Concat` segments, the largest being an `Alias`.
+const MAX_CURSOR_KEY: u32 = 160;
+
+/// Which map [`MigrateCoinageToInstances`] is working through, and where it got to.
+///
+/// Phases run in the listed order and each carries the raw key it last handled, so a step resumes
+/// exactly where the previous one stopped.
+#[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Clone, PartialEq, Eq, Debug)]
+pub enum Phase {
+	/// 816 balances: rehash `Twox64Concat` -> `Blake2_128Concat` and widen `Coin`.
+	CoinsByOwner(Option<BoundedVec<u8, ConstU32<MAX_CURSOR_KEY>>>),
+	/// 17 entries: rehash only; the value bytes are already correct.
+	LockedCoins(Option<BoundedVec<u8, ConstU32<MAX_CURSOR_KEY>>>),
+	/// 5,735 entries: rehash and widen the value to `(InstanceId, Denomination)`.
+	RecyclersCoinToRecycler(Option<BoundedVec<u8, ConstU32<MAX_CURSOR_KEY>>>),
+	/// 🔴 385 entries: rebuild the anti-replay set into `RecyclerAliasStates`.
+	RecyclersUnloaded(Option<BoundedVec<u8, ConstU32<MAX_CURSOR_KEY>>>),
+	/// Drop the 15 baseline `RecyclerCollectionCreated` keys, which sit inside the new double
+	/// map's prefix. Unit A already wrote their replacements.
+	OldCollectionMarkers(Option<BoundedVec<u8, ConstU32<MAX_CURSOR_KEY>>>),
+}
+
+/// Unit B — move every per-owner and per-recycler key into its instance-aware shape.
+///
+/// Multi-block by necessity: ~6,900 entries, and the binding constraint is PoV, not ref-time —
+/// each read contributes trie proof nodes against a ~5 MB budget.
+///
+/// 🔴 Every step must be panic-free. People binds `FreezeChainOnFailedMigration`, so a panic here
+/// freezes the chain. Entries whose old value does not decode are counted and skipped rather than
+/// asserted on; `post_upgrade` is where a non-zero count becomes an error, by which point the
+/// migration has already finished and the chain is live.
+pub struct MigrateCoinageToInstances;
+
+impl SteppedMigration for MigrateCoinageToInstances {
+	type Cursor = Phase;
+	type Identifier = MigrationId<32>;
+
+	fn id() -> Self::Identifier {
+		MigrationId {
+			pallet_id: *b"paseo-coinage-to-instances------",
+			version_from: 0,
+			version_to: 1,
+		}
+	}
+
+	fn step(
+		cursor: Option<Self::Cursor>,
+		meter: &mut WeightMeter,
+	) -> Result<Option<Self::Cursor>, SteppedMigrationError> {
+		let required = per_entry_weight();
+		if meter.remaining().any_lt(required) {
+			return Err(SteppedMigrationError::InsufficientWeight { required });
+		}
+
+		let mut phase = cursor.unwrap_or(Phase::CoinsByOwner(None));
+
+		loop {
+			if meter.try_consume(required).is_err() {
+				return Ok(Some(phase));
+			}
+
+			phase = match phase {
+				Phase::CoinsByOwner(last) => match step_coins_by_owner(last) {
+					Some(next) => Phase::CoinsByOwner(Some(next)),
+					None => Phase::LockedCoins(None),
+				},
+				Phase::LockedCoins(last) => match step_locked_coins(last) {
+					Some(next) => Phase::LockedCoins(Some(next)),
+					None => Phase::RecyclersCoinToRecycler(None),
+				},
+				Phase::RecyclersCoinToRecycler(last) => match step_coin_to_recycler(last) {
+					Some(next) => Phase::RecyclersCoinToRecycler(Some(next)),
+					None => Phase::RecyclersUnloaded(None),
+				},
+				Phase::RecyclersUnloaded(last) => match step_recyclers_unloaded(last) {
+					Some(next) => Phase::RecyclersUnloaded(Some(next)),
+					None => Phase::OldCollectionMarkers(None),
+				},
+				Phase::OldCollectionMarkers(last) => match step_old_markers(last) {
+					Some(next) => Phase::OldCollectionMarkers(Some(next)),
+					None => return Ok(None),
+				},
+			};
+		}
+	}
+}
+
+/// Bound a raw key for the cursor. A key that does not fit is impossible for these maps; returning
+/// `None` stops the phase rather than truncating, which would silently restart it.
+fn bound_key(raw: alloc::vec::Vec<u8>) -> Option<BoundedVec<u8, ConstU32<MAX_CURSOR_KEY>>> {
+	BoundedVec::try_from(raw).ok()
+}
+
+fn resume<'a>(last: &'a Option<BoundedVec<u8, ConstU32<MAX_CURSOR_KEY>>>) -> Option<&'a [u8]> {
+	last.as_ref().map(|k| k.as_slice())
+}
+
+/// One `CoinsByOwner` entry: rehash the key and widen `Coin` with `instance_id = 0`.
+fn step_coins_by_owner(
+	last: Option<BoundedVec<u8, ConstU32<MAX_CURSOR_KEY>>>,
+) -> Option<BoundedVec<u8, ConstU32<MAX_CURSOR_KEY>>> {
+	let mut iter = match resume(&last) {
+		Some(k) => old::CoinsByOwner::<Runtime>::iter_from(k.to_vec()),
+		None => old::CoinsByOwner::<Runtime>::iter(),
+	};
+	let (account, old_coin) = iter.next()?;
+	let raw = old::CoinsByOwner::<Runtime>::hashed_key_for(&account);
+
+	// `instance_id` is prepended, so the widened value is a strict extension of the old one.
+	indiv_pallet_coinage::CoinsByOwner::<Runtime>::insert(
+		&account,
+		Coin { instance_id: LEGACY_INSTANCE_ID, value: old_coin.value, age: old_coin.age },
+	);
+	old::CoinsByOwner::<Runtime>::remove(&account);
+	bound_key(raw)
+}
+
+/// One `LockedCoins` entry: the value bytes are already correct, only the hasher moves.
+fn step_locked_coins(
+	last: Option<BoundedVec<u8, ConstU32<MAX_CURSOR_KEY>>>,
+) -> Option<BoundedVec<u8, ConstU32<MAX_CURSOR_KEY>>> {
+	let mut iter = match resume(&last) {
+		Some(k) => old::LockedCoins::<Runtime>::iter_from(k.to_vec()),
+		None => old::LockedCoins::<Runtime>::iter(),
+	};
+	let (account, lock) = iter.next()?;
+	let raw = old::LockedCoins::<Runtime>::hashed_key_for(&account);
+
+	indiv_pallet_coinage::LockedCoins::<Runtime>::insert(&account, lock);
+	old::LockedCoins::<Runtime>::remove(&account);
+	bound_key(raw)
+}
+
+/// One `RecyclersCoinToRecycler` entry: rehash, and widen the bare denomination into
+/// `(instance_id, denomination)`.
+fn step_coin_to_recycler(
+	last: Option<BoundedVec<u8, ConstU32<MAX_CURSOR_KEY>>>,
+) -> Option<BoundedVec<u8, ConstU32<MAX_CURSOR_KEY>>> {
+	let mut iter = match resume(&last) {
+		Some(k) => old::RecyclersCoinToRecycler::<Runtime>::iter_from(k.to_vec()),
+		None => old::RecyclersCoinToRecycler::<Runtime>::iter(),
+	};
+	let (member, denomination) = iter.next()?;
+	let raw = old::RecyclersCoinToRecycler::<Runtime>::hashed_key_for(&member);
+
+	RecyclersCoinToRecycler::<Runtime>::insert(&member, (LEGACY_INSTANCE_ID, denomination));
+	old::RecyclersCoinToRecycler::<Runtime>::remove(&member);
+	bound_key(raw)
+}
+
+/// 🔴 One anti-replay entry, rebuilt into `RecyclerAliasStates`.
+///
+/// The value must be `AliasState::Unloaded`, which is **variant index 1** — encoding `0x01`.
+/// Writing `0x00` would be a truncated `Locked`, which fails to decode, which `OptionQuery` turns
+/// into `None`, which the replay guard reads as *available*. A mis-encoded entry is
+/// indistinguishable from a missing one and reintroduces exactly the double-unload this exists to
+/// prevent.
+///
+/// Deliberately does **not** write `RecyclersUnloadedCount`. individuality v0.3.1 added that
+/// counter and documents the migrated case: "a ring that already had alias states when
+/// `RecyclersUnloadedCount` was introduced is never counted, so a caller that needs its number has
+/// to scan `RecyclerAliasStates`". Seeding it would risk a `defensive!` mismatch at ring removal.
+fn step_recyclers_unloaded(
+	last: Option<BoundedVec<u8, ConstU32<MAX_CURSOR_KEY>>>,
+) -> Option<BoundedVec<u8, ConstU32<MAX_CURSOR_KEY>>> {
+	let mut iter = match resume(&last) {
+		Some(k) => old::RecyclersUnloaded::<Runtime>::iter_keys_from(k.to_vec()),
+		None => old::RecyclersUnloaded::<Runtime>::iter_keys(),
+	};
+	let (denomination, ring, alias) = iter.next()?;
+	let raw = old::RecyclersUnloaded::<Runtime>::hashed_key_for((denomination, ring, alias));
+
+	RecyclerAliasStates::<Runtime>::insert(
+		(LEGACY_INSTANCE_ID, denomination, ring, alias),
+		AliasState::Unloaded,
+	);
+	old::RecyclersUnloaded::<Runtime>::remove((denomination, ring, alias));
+	bound_key(raw)
+}
+
+/// One baseline `RecyclerCollectionCreated` key. Unit A already wrote the double-map replacement;
+/// this drops the old key, which would otherwise sit inside the new map's own prefix.
+fn step_old_markers(
+	last: Option<BoundedVec<u8, ConstU32<MAX_CURSOR_KEY>>>,
+) -> Option<BoundedVec<u8, ConstU32<MAX_CURSOR_KEY>>> {
+	let mut iter = match resume(&last) {
+		Some(k) => old::RecyclerCollectionCreated::<Runtime>::iter_keys_from(k.to_vec()),
+		None => old::RecyclerCollectionCreated::<Runtime>::iter_keys(),
+	};
+	let denomination = iter.next()?;
+	let raw = old::RecyclerCollectionCreated::<Runtime>::hashed_key_for(denomination);
+	old::RecyclerCollectionCreated::<Runtime>::remove(denomination);
+	bound_key(raw)
+}
+
+#[cfg(feature = "try-runtime")]
+mod unit_b_checks {
+	use super::*;
+	use codec::{Decode, Encode};
+
+	/// What `pre_upgrade` hands to `post_upgrade`: the exact population to account for.
+	#[derive(Encode, Decode)]
+	pub struct Captured {
+		pub coins: u32,
+		pub locked: u32,
+		pub coin_to_recycler: u32,
+		pub unloaded: u32,
+		pub markers: u32,
+	}
+
+	impl MigrateCoinageToInstances {
+		pub fn capture() -> Captured {
+			Captured {
+				coins: old::CoinsByOwner::<Runtime>::iter_keys().count() as u32,
+				locked: old::LockedCoins::<Runtime>::iter_keys().count() as u32,
+				coin_to_recycler: old::RecyclersCoinToRecycler::<Runtime>::iter_keys().count()
+					as u32,
+				unloaded: old::RecyclersUnloaded::<Runtime>::iter_keys().count() as u32,
+				markers: old::RecyclerCollectionCreated::<Runtime>::iter_keys().count() as u32,
+			}
+		}
+	}
+}
+
+#[cfg(feature = "try-runtime")]
+impl MigrateCoinageToInstances {
+	/// Counts taken from live state, never from a documented figure — the design's
+	/// `RecyclersCoinToRecycler` number was already stale by 24 entries when re-read.
+	pub fn pre_upgrade_state() -> Result<alloc::vec::Vec<u8>, sp_runtime::TryRuntimeError> {
+		use codec::Encode;
+
+		ensure!(
+			Instances::<Runtime>::contains_key(LEGACY_INSTANCE_ID),
+			"coinage: unit A must run before unit B; instance 0 is not seeded",
+		);
+
+		let captured = Self::capture();
+		log::info!(
+			target: "runtime::coinage-migration",
+			"pre_upgrade: {} coins, {} locked, {} coin->recycler, {} unloaded (anti-replay), \
+			 {} legacy markers",
+			captured.coins, captured.locked, captured.coin_to_recycler, captured.unloaded,
+			captured.markers,
+		);
+		Ok(captured.encode())
+	}
+
+	/// The load-bearing check. Two independent things must hold:
+	///
+	/// 1. **Every old key is gone.** `PrefixIterator` silently skips an entry whose value fails to
+	///    decode, leaving it in storage — so an emptiness assertion is the only way that surfaces.
+	///    It fires after the chain is live rather than freezing it mid-step.
+	/// 2. **Every entry landed**, counted against the `pre_upgrade` capture rather than a literal.
+	pub fn post_upgrade_state(
+		state: alloc::vec::Vec<u8>,
+	) -> Result<(), sp_runtime::TryRuntimeError> {
+		use codec::Decode;
+		use unit_b_checks::Captured;
+
+		let before: Captured = Decode::decode(&mut &state[..])
+			.map_err(|_| "coinage: could not decode the pre_upgrade capture")?;
+
+		ensure!(
+			old::CoinsByOwner::<Runtime>::iter_keys().next().is_none(),
+			"coinage: a baseline CoinsByOwner key survived — an entry failed to decode and was skipped",
+		);
+		ensure!(
+			old::LockedCoins::<Runtime>::iter_keys().next().is_none(),
+			"coinage: a baseline LockedCoins key survived",
+		);
+		ensure!(
+			old::RecyclersCoinToRecycler::<Runtime>::iter_keys().next().is_none(),
+			"coinage: a baseline RecyclersCoinToRecycler key survived",
+		);
+		ensure!(
+			old::RecyclersUnloaded::<Runtime>::iter_keys().next().is_none(),
+			"coinage: a baseline RecyclersUnloaded key survived — the anti-replay set is not fully rebuilt",
+		);
+		ensure!(
+			old::RecyclerCollectionCreated::<Runtime>::iter_keys().next().is_none(),
+			"coinage: a baseline RecyclerCollectionCreated key survived inside the new double map",
+		);
+
+		let coins = indiv_pallet_coinage::CoinsByOwner::<Runtime>::iter_keys().count() as u32;
+		ensure!(coins == before.coins, "coinage: CoinsByOwner lost or gained entries");
+
+		let locked = indiv_pallet_coinage::LockedCoins::<Runtime>::iter_keys().count() as u32;
+		ensure!(locked == before.locked, "coinage: LockedCoins lost or gained entries");
+
+		let c2r = RecyclersCoinToRecycler::<Runtime>::iter_keys().count() as u32;
+		ensure!(
+			c2r == before.coin_to_recycler,
+			"coinage: RecyclersCoinToRecycler lost or gained entries",
+		);
+
+		// 🔴 The anti-replay rebuild. Every previously-consumed alias must now read as `Unloaded`;
+		// one that reads `None` is spendable again.
+		let states = RecyclerAliasStates::<Runtime>::iter().count() as u32;
+		ensure!(
+			states == before.unloaded,
+			"coinage: RecyclerAliasStates does not account for every previously-unloaded alias",
+		);
+		for (_, state) in RecyclerAliasStates::<Runtime>::iter() {
+			ensure!(
+				state == AliasState::Unloaded,
+				"coinage: a rebuilt alias state is not Unloaded",
+			);
+		}
+
+		// Every coin must belong to the seeded instance; a stray id would be unspendable.
+		for (_, coin) in indiv_pallet_coinage::CoinsByOwner::<Runtime>::iter() {
+			ensure!(
+				coin.instance_id == LEGACY_INSTANCE_ID,
+				"coinage: a migrated coin is not in the seeded instance",
+			);
+		}
+
+		log::info!(
+			target: "runtime::coinage-migration",
+			"post_upgrade: {coins} coins, {locked} locked, {c2r} coin->recycler and {states} \
+			 anti-replay entries verified against the pre_upgrade capture",
 		);
 		Ok(())
 	}

--- a/system-parachains/people-paseo/src/migrations/coinage.rs
+++ b/system-parachains/people-paseo/src/migrations/coinage.rs
@@ -334,12 +334,46 @@ impl OnRuntimeUpgrade for SeedCoinageInstanceZero {
 	}
 }
 
-/// How much of one entry's work a single step charges: read the old key, write the new one, kill
-/// the old one. Deliberately generous — PoV, not ref-time, is the binding constraint here, and the
-/// meter stops us long before the block does.
+/// Declared `proof_size` charged per migrated entry, in bytes.
+///
+/// 🔴 THIS IS THE NUMBER THAT PROTECTS BLOCK PRODUCTION, and it must be an OVER-estimate.
+///
+/// `RuntimeDbWeight::reads_writes()` declares `proof_size = 0`. On a parachain PoV is the binding
+/// constraint, not ref-time, so a step weight built from `DbWeight` alone tells the `WeightMeter`
+/// that entries are free in PoV. The meter would then let a step process thousands of them while
+/// the real proof grows past `MAX_POV_SIZE`, the relay rejects the block, and **block production
+/// stalls**. Under-declaring here is the single most dangerous thing this file could do.
+///
+/// A trie proof node set for one key is roughly 0.5–2 KB. 4 KB is deliberately about double the
+/// top of that range. Against the ~4 MB the MBM budget allows per block
+/// (`MbmServiceWeight` = 80% of `max_block`), that admits ~1,000 entries per block:
+///
+/// | unit | entries | blocks at 4 KB |
+/// | --- | --- | --- |
+/// | B | ~6,900 | ~7 |
+/// | C | ~12,000 | ~12 |
+///
+/// Being wrong in the generous direction costs extra blocks. Being wrong in the other direction
+/// costs the chain. Do not lower this without measuring a real proof on a real snapshot.
+const DECLARED_PROOF_SIZE_PER_ENTRY: u64 = 4 * 1024;
+
+/// The weight one migrated entry is charged: a read, two writes, and a deliberately generous
+/// `proof_size` allowance the `DbWeight` figures do not include.
 fn per_entry_weight() -> Weight {
-	<Runtime as frame_system::Config>::DbWeight::get().reads_writes(1, 2)
+	<Runtime as frame_system::Config>::DbWeight::get()
+		.reads_writes(1, 2)
+		.saturating_add(Weight::from_parts(0, DECLARED_PROOF_SIZE_PER_ENTRY))
 }
+
+/// Upper bound on `step()` invocations before `pallet_migrations` gives up.
+///
+/// Expected is ~20 for B and C together. 10,000 is ~500x that: it can only be reached by a genuine
+/// bug such as a cursor that fails to advance, and it bounds a runaway rather than letting one spin
+/// forever.
+///
+/// ⚠️ On this chain exceeding it is not a soft failure: People binds
+/// `FreezeChainOnFailedMigration`. The bound is set far above any legitimate run for that reason.
+const MAX_MIGRATION_STEPS: u32 = 10_000;
 
 /// The longest raw storage key any phase resumes from. The widest is the `RecyclersUnloaded`
 /// n-map: 32-byte item prefix + three `Twox64Concat` segments, the largest being an `Alias`.
@@ -387,6 +421,10 @@ impl SteppedMigration for MigrateCoinageToInstances {
 		}
 	}
 
+	fn max_steps() -> Option<u32> {
+		Some(MAX_MIGRATION_STEPS)
+	}
+
 	fn step(
 		cursor: Option<Self::Cursor>,
 		meter: &mut WeightMeter,
@@ -403,36 +441,64 @@ impl SteppedMigration for MigrateCoinageToInstances {
 				return Ok(Some(phase));
 			}
 
+			// `Done` and `Halt` both leave the current prefix, but only `Halt` means something
+			// went wrong; the leftover keys make it detectable in `post_upgrade`.
 			phase = match phase {
 				Phase::CoinsByOwner(last) => match step_coins_by_owner(last) {
-					Some(next) => Phase::CoinsByOwner(Some(next)),
-					None => Phase::LockedCoins(None),
+					StepOutcome::Next(k) => Phase::CoinsByOwner(Some(k)),
+					StepOutcome::Done | StepOutcome::Halt => Phase::LockedCoins(None),
 				},
 				Phase::LockedCoins(last) => match step_locked_coins(last) {
-					Some(next) => Phase::LockedCoins(Some(next)),
-					None => Phase::RecyclersCoinToRecycler(None),
+					StepOutcome::Next(k) => Phase::LockedCoins(Some(k)),
+					StepOutcome::Done | StepOutcome::Halt => Phase::RecyclersCoinToRecycler(None),
 				},
 				Phase::RecyclersCoinToRecycler(last) => match step_coin_to_recycler(last) {
-					Some(next) => Phase::RecyclersCoinToRecycler(Some(next)),
-					None => Phase::RecyclersUnloaded(None),
+					StepOutcome::Next(k) => Phase::RecyclersCoinToRecycler(Some(k)),
+					StepOutcome::Done | StepOutcome::Halt => Phase::RecyclersUnloaded(None),
 				},
 				Phase::RecyclersUnloaded(last) => match step_recyclers_unloaded(last) {
-					Some(next) => Phase::RecyclersUnloaded(Some(next)),
-					None => Phase::OldCollectionMarkers(None),
+					StepOutcome::Next(k) => Phase::RecyclersUnloaded(Some(k)),
+					StepOutcome::Done | StepOutcome::Halt => Phase::OldCollectionMarkers(None),
 				},
 				Phase::OldCollectionMarkers(last) => match step_old_markers(last) {
-					Some(next) => Phase::OldCollectionMarkers(Some(next)),
-					None => return Ok(None),
+					StepOutcome::Next(k) => Phase::OldCollectionMarkers(Some(k)),
+					StepOutcome::Done | StepOutcome::Halt => return Ok(None),
 				},
 			};
 		}
 	}
 }
 
-/// Bound a raw key for the cursor. A key that does not fit is impossible for these maps; returning
-/// `None` stops the phase rather than truncating, which would silently restart it.
-fn bound_key(raw: alloc::vec::Vec<u8>) -> Option<BoundedVec<u8, ConstU32<MAX_CURSOR_KEY>>> {
-	BoundedVec::try_from(raw).ok()
+/// What one entry-level step produced.
+///
+/// The point of this enum is that [`Self::Done`] and [`Self::Halt`] are different. Both stop the
+/// current prefix, but `Halt` means *we could not continue*, which leaves old keys behind — and
+/// `post_upgrade`'s emptiness assertions are guaranteed to catch that. Collapsing the two into a
+/// bare `None`, as an earlier revision did, is what would turn a cursor failure into silent data
+/// loss.
+enum StepOutcome {
+	/// Migrated one entry; resume after this raw key.
+	Next(BoundedVec<u8, ConstU32<MAX_CURSOR_KEY>>),
+	/// No entries left under this prefix.
+	Done,
+	/// Could not continue. Logged, and detectable afterwards by the leftover keys.
+	Halt,
+}
+
+/// Bound a raw key for the cursor.
+///
+/// 🔴 Every key these phases produce has a fixed shape, so this cannot fail in practice — but if
+/// it did, returning a value the caller reads as "prefix finished" would **silently skip every
+/// remaining entry under it**. That is data loss, and invisible until a balance is missing. So a
+/// failure is logged loudly and surfaced as an error the caller must handle by stopping.
+fn bound_key(raw: alloc::vec::Vec<u8>) -> Result<BoundedVec<u8, ConstU32<MAX_CURSOR_KEY>>, ()> {
+	BoundedVec::try_from(raw).map_err(|k: alloc::vec::Vec<u8>| {
+		log::error!(
+			target: "runtime::coinage-migration",
+			"cursor key of {} bytes exceeds MAX_CURSOR_KEY ({MAX_CURSOR_KEY}); stopping this phase",
+			k.len(),
+		);
+	})
 }
 
 fn resume<'a>(last: &'a Option<BoundedVec<u8, ConstU32<MAX_CURSOR_KEY>>>) -> Option<&'a [u8]> {
@@ -440,14 +506,12 @@ fn resume<'a>(last: &'a Option<BoundedVec<u8, ConstU32<MAX_CURSOR_KEY>>>) -> Opt
 }
 
 /// One `CoinsByOwner` entry: rehash the key and widen `Coin` with `instance_id = 0`.
-fn step_coins_by_owner(
-	last: Option<BoundedVec<u8, ConstU32<MAX_CURSOR_KEY>>>,
-) -> Option<BoundedVec<u8, ConstU32<MAX_CURSOR_KEY>>> {
+fn step_coins_by_owner(last: Option<BoundedVec<u8, ConstU32<MAX_CURSOR_KEY>>>) -> StepOutcome {
 	let mut iter = match resume(&last) {
 		Some(k) => old::CoinsByOwner::<Runtime>::iter_from(k.to_vec()),
 		None => old::CoinsByOwner::<Runtime>::iter(),
 	};
-	let (account, old_coin) = iter.next()?;
+	let Some((account, old_coin)) = iter.next() else { return StepOutcome::Done };
 	let raw = old::CoinsByOwner::<Runtime>::hashed_key_for(&account);
 
 	// `instance_id` is prepended, so the widened value is a strict extension of the old one.
@@ -456,40 +520,45 @@ fn step_coins_by_owner(
 		Coin { instance_id: LEGACY_INSTANCE_ID, value: old_coin.value, age: old_coin.age },
 	);
 	old::CoinsByOwner::<Runtime>::remove(&account);
-	bound_key(raw)
+	match bound_key(raw) {
+		Ok(k) => StepOutcome::Next(k),
+		Err(()) => StepOutcome::Halt,
+	}
 }
 
 /// One `LockedCoins` entry: the value bytes are already correct, only the hasher moves.
-fn step_locked_coins(
-	last: Option<BoundedVec<u8, ConstU32<MAX_CURSOR_KEY>>>,
-) -> Option<BoundedVec<u8, ConstU32<MAX_CURSOR_KEY>>> {
+fn step_locked_coins(last: Option<BoundedVec<u8, ConstU32<MAX_CURSOR_KEY>>>) -> StepOutcome {
 	let mut iter = match resume(&last) {
 		Some(k) => old::LockedCoins::<Runtime>::iter_from(k.to_vec()),
 		None => old::LockedCoins::<Runtime>::iter(),
 	};
-	let (account, lock) = iter.next()?;
+	let Some((account, lock)) = iter.next() else { return StepOutcome::Done };
 	let raw = old::LockedCoins::<Runtime>::hashed_key_for(&account);
 
 	indiv_pallet_coinage::LockedCoins::<Runtime>::insert(&account, lock);
 	old::LockedCoins::<Runtime>::remove(&account);
-	bound_key(raw)
+	match bound_key(raw) {
+		Ok(k) => StepOutcome::Next(k),
+		Err(()) => StepOutcome::Halt,
+	}
 }
 
 /// One `RecyclersCoinToRecycler` entry: rehash, and widen the bare denomination into
 /// `(instance_id, denomination)`.
-fn step_coin_to_recycler(
-	last: Option<BoundedVec<u8, ConstU32<MAX_CURSOR_KEY>>>,
-) -> Option<BoundedVec<u8, ConstU32<MAX_CURSOR_KEY>>> {
+fn step_coin_to_recycler(last: Option<BoundedVec<u8, ConstU32<MAX_CURSOR_KEY>>>) -> StepOutcome {
 	let mut iter = match resume(&last) {
 		Some(k) => old::RecyclersCoinToRecycler::<Runtime>::iter_from(k.to_vec()),
 		None => old::RecyclersCoinToRecycler::<Runtime>::iter(),
 	};
-	let (member, denomination) = iter.next()?;
+	let Some((member, denomination)) = iter.next() else { return StepOutcome::Done };
 	let raw = old::RecyclersCoinToRecycler::<Runtime>::hashed_key_for(&member);
 
 	RecyclersCoinToRecycler::<Runtime>::insert(&member, (LEGACY_INSTANCE_ID, denomination));
 	old::RecyclersCoinToRecycler::<Runtime>::remove(&member);
-	bound_key(raw)
+	match bound_key(raw) {
+		Ok(k) => StepOutcome::Next(k),
+		Err(()) => StepOutcome::Halt,
+	}
 }
 
 /// 🔴 One anti-replay entry, rebuilt into `RecyclerAliasStates`.
@@ -504,14 +573,12 @@ fn step_coin_to_recycler(
 /// counter and documents the migrated case: "a ring that already had alias states when
 /// `RecyclersUnloadedCount` was introduced is never counted, so a caller that needs its number has
 /// to scan `RecyclerAliasStates`". Seeding it would risk a `defensive!` mismatch at ring removal.
-fn step_recyclers_unloaded(
-	last: Option<BoundedVec<u8, ConstU32<MAX_CURSOR_KEY>>>,
-) -> Option<BoundedVec<u8, ConstU32<MAX_CURSOR_KEY>>> {
+fn step_recyclers_unloaded(last: Option<BoundedVec<u8, ConstU32<MAX_CURSOR_KEY>>>) -> StepOutcome {
 	let mut iter = match resume(&last) {
 		Some(k) => old::RecyclersUnloaded::<Runtime>::iter_keys_from(k.to_vec()),
 		None => old::RecyclersUnloaded::<Runtime>::iter_keys(),
 	};
-	let (denomination, ring, alias) = iter.next()?;
+	let Some((denomination, ring, alias)) = iter.next() else { return StepOutcome::Done };
 	let raw = old::RecyclersUnloaded::<Runtime>::hashed_key_for((denomination, ring, alias));
 
 	RecyclerAliasStates::<Runtime>::insert(
@@ -519,22 +586,26 @@ fn step_recyclers_unloaded(
 		AliasState::Unloaded,
 	);
 	old::RecyclersUnloaded::<Runtime>::remove((denomination, ring, alias));
-	bound_key(raw)
+	match bound_key(raw) {
+		Ok(k) => StepOutcome::Next(k),
+		Err(()) => StepOutcome::Halt,
+	}
 }
 
 /// One baseline `RecyclerCollectionCreated` key. Unit A already wrote the double-map replacement;
 /// this drops the old key, which would otherwise sit inside the new map's own prefix.
-fn step_old_markers(
-	last: Option<BoundedVec<u8, ConstU32<MAX_CURSOR_KEY>>>,
-) -> Option<BoundedVec<u8, ConstU32<MAX_CURSOR_KEY>>> {
+fn step_old_markers(last: Option<BoundedVec<u8, ConstU32<MAX_CURSOR_KEY>>>) -> StepOutcome {
 	let mut iter = match resume(&last) {
 		Some(k) => old::RecyclerCollectionCreated::<Runtime>::iter_keys_from(k.to_vec()),
 		None => old::RecyclerCollectionCreated::<Runtime>::iter_keys(),
 	};
-	let denomination = iter.next()?;
+	let Some(denomination) = iter.next() else { return StepOutcome::Done };
 	let raw = old::RecyclerCollectionCreated::<Runtime>::hashed_key_for(denomination);
 	old::RecyclerCollectionCreated::<Runtime>::remove(denomination);
-	bound_key(raw)
+	match bound_key(raw) {
+		Ok(k) => StepOutcome::Next(k),
+		Err(()) => StepOutcome::Halt,
+	}
 }
 
 #[cfg(feature = "try-runtime")]
@@ -766,6 +837,10 @@ impl SteppedMigration for RelocateCoinageRecyclerCollections {
 		}
 	}
 
+	fn max_steps() -> Option<u32> {
+		Some(MAX_MIGRATION_STEPS)
+	}
+
 	fn step(
 		cursor: Option<Self::Cursor>,
 		meter: &mut WeightMeter,
@@ -847,8 +922,10 @@ fn step_relocate_keys(
 	}
 
 	match bound_key(key) {
-		Some(k) => Relocation::Keys { item, denomination, last: Some(k) },
-		None => advance(item, denomination),
+		Ok(k) => Relocation::Keys { item, denomination, last: Some(k) },
+		// Cannot advance the cursor, so leave this prefix rather than loop. The un-relocated
+		// keys are what `post_upgrade` detects.
+		Err(()) => advance(item, denomination),
 	}
 }
 

--- a/system-parachains/people-paseo/src/migrations/coinage.rs
+++ b/system-parachains/people-paseo/src/migrations/coinage.rs
@@ -55,7 +55,7 @@
 //! | `RecyclersLastRemovedRingIndex`, `RecyclersDusting`, `PaidUnloadTokenMembers` | 0 |
 //! | `Instances` | 0 — nothing seeded yet |
 
-use crate::{Runtime, Weight};
+use crate::{AccountId, Runtime, Weight};
 use frame_support::{
 	migrations::{MigrationId, SteppedMigration, SteppedMigrationError},
 	pallet_prelude::*,
@@ -505,21 +505,108 @@ fn resume<'a>(last: &'a Option<BoundedVec<u8, ConstU32<MAX_CURSOR_KEY>>>) -> Opt
 	last.as_ref().map(|k| k.as_slice())
 }
 
+// ---------------------------------------------------------------------------------------------
+// 🔴 Why every phase below walks RAW keys instead of the typed legacy alias
+//
+// For `CoinsByOwner`, `LockedCoins`, `RecyclersCoinToRecycler` and `RecyclerCollectionCreated`,
+// v0.3.1 changed only the HASHER (or the map arity) — pallet and item names are unchanged, so
+// **source and destination share one storage prefix**. A freshly written destination key lands
+// inside the range a legacy-typed iterator walks.
+//
+// And it is NOT skipped. Reversing `Twox64Concat` over a 48-byte `Blake2_128Concat` suffix yields
+// 8 hash bytes and 40 remaining; `AccountId32` decodes from the first 32 and SCALE ignores the 8
+// trailing, so it succeeds with a garbage account. The migration then reads its own output back as
+// input, writes another key from the garbage account, and never terminates. Measured: unit B ran
+// 500 simulated blocks against a real snapshot without finishing.
+//
+// Legacy and destination keys differ in LENGTH, and that is what separates them:
+//
+// | item | legacy suffix | destination suffix |
+// | --- | --- | --- |
+// | `CoinsByOwner`, `LockedCoins`, `RecyclersCoinToRecycler` | 8 + 32 = 40 | 16 + 32 = 48 |
+// | `RecyclerCollectionCreated` | 8 + 1 = 9 | (8+4) + (8+1) = 21 |
+//
+// `RecyclersUnloaded` -> `RecyclerAliasStates` is the one safe case: different item names, so
+// different prefixes, so no overlap.
+// ---------------------------------------------------------------------------------------------
+
+/// `twox128("Coinage") ++ twox128(item)`.
+fn coinage_item_prefix(item: &str) -> alloc::vec::Vec<u8> {
+	let mut key = alloc::vec::Vec::with_capacity(32);
+	key.extend_from_slice(&sp_io::hashing::twox_128(b"Coinage"));
+	key.extend_from_slice(&sp_io::hashing::twox_128(item.as_bytes()));
+	key
+}
+
+/// Legacy suffix length for a `Twox64Concat` map over a fixed-size key: 8 hash bytes + the key.
+const fn twox64_suffix(key_len: usize) -> usize {
+	8 + key_len
+}
+
+/// Next raw key under `item_prefix` after `from` whose suffix length is exactly
+/// `legacy_suffix_len`, skipping everything else — which is this migration's own output.
+///
+/// Bounded: stops at the end of the prefix or after `SCAN_LIMIT` non-matching keys, so it can
+/// never spin. Hitting the limit ends the phase, and `post_upgrade`'s emptiness assertion catches
+/// whatever was left.
+fn next_legacy_key(
+	item_prefix: &[u8],
+	from: &[u8],
+	legacy_suffix_len: usize,
+) -> Option<alloc::vec::Vec<u8>> {
+	const SCAN_LIMIT: u32 = 10_000;
+	let mut cursor = from.to_vec();
+	for _ in 0..SCAN_LIMIT {
+		let next = sp_io::storage::next_key(&cursor)?;
+		if !next.starts_with(item_prefix) {
+			return None;
+		}
+		if next.len() == item_prefix.len().saturating_add(legacy_suffix_len) {
+			return Some(next);
+		}
+		cursor = next;
+	}
+	log::error!(
+		target: "runtime::coinage-migration",
+		"scan limit reached looking for a legacy key; ending this phase",
+	);
+	None
+}
+
+/// Decode a map key out of a raw storage key whose suffix is `hash ++ encoded_key`.
+fn key_from_raw<K: Decode>(raw: &[u8], item_prefix_len: usize, hash_len: usize) -> Option<K> {
+	let start = item_prefix_len.saturating_add(hash_len);
+	let mut encoded = raw.get(start..)?;
+	K::decode(&mut encoded).ok()
+}
+
 /// One `CoinsByOwner` entry: rehash the key and widen `Coin` with `instance_id = 0`.
 fn step_coins_by_owner(last: Option<BoundedVec<u8, ConstU32<MAX_CURSOR_KEY>>>) -> StepOutcome {
-	let mut iter = match resume(&last) {
-		Some(k) => old::CoinsByOwner::<Runtime>::iter_from(k.to_vec()),
-		None => old::CoinsByOwner::<Runtime>::iter(),
+	let prefix = coinage_item_prefix("CoinsByOwner");
+	let from = resume(&last).map(|k| k.to_vec()).unwrap_or_else(|| prefix.clone());
+	let Some(raw) = next_legacy_key(&prefix, &from, twox64_suffix(32)) else {
+		return StepOutcome::Done;
 	};
-	let Some((account, old_coin)) = iter.next() else { return StepOutcome::Done };
-	let raw = old::CoinsByOwner::<Runtime>::hashed_key_for(&account);
+	let Some(account) = key_from_raw::<AccountId>(&raw, prefix.len(), 8) else {
+		log::error!(target: "runtime::coinage-migration", "undecodable CoinsByOwner key; halting");
+		return StepOutcome::Halt;
+	};
+	let Some(old_coin) = old::CoinsByOwner::<Runtime>::get(&account) else {
+		// A key that is present but whose value will not decode. Do NOT clear it: leaving it makes
+		// `post_upgrade`'s emptiness assertion fail loudly instead of losing a balance quietly.
+		log::error!(
+			target: "runtime::coinage-migration",
+			"CoinsByOwner value did not decode; leaving the key for post_upgrade to catch",
+		);
+		return StepOutcome::Halt;
+	};
 
-	// `instance_id` is prepended, so the widened value is a strict extension of the old one.
+	// `instance_id` is prepended, so the widened value strictly extends the old one.
 	indiv_pallet_coinage::CoinsByOwner::<Runtime>::insert(
 		&account,
 		Coin { instance_id: LEGACY_INSTANCE_ID, value: old_coin.value, age: old_coin.age },
 	);
-	old::CoinsByOwner::<Runtime>::remove(&account);
+	sp_io::storage::clear(&raw);
 	match bound_key(raw) {
 		Ok(k) => StepOutcome::Next(k),
 		Err(()) => StepOutcome::Halt,
@@ -528,15 +615,23 @@ fn step_coins_by_owner(last: Option<BoundedVec<u8, ConstU32<MAX_CURSOR_KEY>>>) -
 
 /// One `LockedCoins` entry: the value bytes are already correct, only the hasher moves.
 fn step_locked_coins(last: Option<BoundedVec<u8, ConstU32<MAX_CURSOR_KEY>>>) -> StepOutcome {
-	let mut iter = match resume(&last) {
-		Some(k) => old::LockedCoins::<Runtime>::iter_from(k.to_vec()),
-		None => old::LockedCoins::<Runtime>::iter(),
+	let prefix = coinage_item_prefix("LockedCoins");
+	let from = resume(&last).map(|k| k.to_vec()).unwrap_or_else(|| prefix.clone());
+	let Some(raw) = next_legacy_key(&prefix, &from, twox64_suffix(32)) else {
+		return StepOutcome::Done;
 	};
-	let Some((account, lock)) = iter.next() else { return StepOutcome::Done };
-	let raw = old::LockedCoins::<Runtime>::hashed_key_for(&account);
+	let Some(account) = key_from_raw::<AccountId>(&raw, prefix.len(), 8) else {
+		log::error!(target: "runtime::coinage-migration", "undecodable LockedCoins key; halting");
+		return StepOutcome::Halt;
+	};
 
-	indiv_pallet_coinage::LockedCoins::<Runtime>::insert(&account, lock);
-	old::LockedCoins::<Runtime>::remove(&account);
+	// `LockedCoin` and `LockInfo` are field-identical, so the value bytes are copied verbatim
+	// rather than decoded and re-encoded.
+	if let Some(value) = sp_io::storage::get(&raw) {
+		let dest = indiv_pallet_coinage::LockedCoins::<Runtime>::hashed_key_for(&account);
+		sp_io::storage::set(&dest, &value);
+	}
+	sp_io::storage::clear(&raw);
 	match bound_key(raw) {
 		Ok(k) => StepOutcome::Next(k),
 		Err(()) => StepOutcome::Halt,
@@ -546,15 +641,28 @@ fn step_locked_coins(last: Option<BoundedVec<u8, ConstU32<MAX_CURSOR_KEY>>>) -> 
 /// One `RecyclersCoinToRecycler` entry: rehash, and widen the bare denomination into
 /// `(instance_id, denomination)`.
 fn step_coin_to_recycler(last: Option<BoundedVec<u8, ConstU32<MAX_CURSOR_KEY>>>) -> StepOutcome {
-	let mut iter = match resume(&last) {
-		Some(k) => old::RecyclersCoinToRecycler::<Runtime>::iter_from(k.to_vec()),
-		None => old::RecyclersCoinToRecycler::<Runtime>::iter(),
+	let prefix = coinage_item_prefix("RecyclersCoinToRecycler");
+	let from = resume(&last).map(|k| k.to_vec()).unwrap_or_else(|| prefix.clone());
+	let Some(raw) = next_legacy_key(&prefix, &from, twox64_suffix(32)) else {
+		return StepOutcome::Done;
 	};
-	let Some((member, denomination)) = iter.next() else { return StepOutcome::Done };
-	let raw = old::RecyclersCoinToRecycler::<Runtime>::hashed_key_for(&member);
+	let Some(member) = key_from_raw::<MemberOf<Runtime>>(&raw, prefix.len(), 8) else {
+		log::error!(
+			target: "runtime::coinage-migration",
+			"undecodable RecyclersCoinToRecycler key; halting",
+		);
+		return StepOutcome::Halt;
+	};
+	let Some(denomination) = old::RecyclersCoinToRecycler::<Runtime>::get(&member) else {
+		log::error!(
+			target: "runtime::coinage-migration",
+			"RecyclersCoinToRecycler value did not decode; leaving the key",
+		);
+		return StepOutcome::Halt;
+	};
 
 	RecyclersCoinToRecycler::<Runtime>::insert(&member, (LEGACY_INSTANCE_ID, denomination));
-	old::RecyclersCoinToRecycler::<Runtime>::remove(&member);
+	sp_io::storage::clear(&raw);
 	match bound_key(raw) {
 		Ok(k) => StepOutcome::Next(k),
 		Err(()) => StepOutcome::Halt,
@@ -595,17 +703,43 @@ fn step_recyclers_unloaded(last: Option<BoundedVec<u8, ConstU32<MAX_CURSOR_KEY>>
 /// One baseline `RecyclerCollectionCreated` key. Unit A already wrote the double-map replacement;
 /// this drops the old key, which would otherwise sit inside the new map's own prefix.
 fn step_old_markers(last: Option<BoundedVec<u8, ConstU32<MAX_CURSOR_KEY>>>) -> StepOutcome {
-	let mut iter = match resume(&last) {
-		Some(k) => old::RecyclerCollectionCreated::<Runtime>::iter_keys_from(k.to_vec()),
-		None => old::RecyclerCollectionCreated::<Runtime>::iter_keys(),
+	// 🔴 Length discrimination is not optional here. The legacy single-map suffix is 9 bytes and
+	// unit A's double-map replacement is 21; a typed legacy iterator decodes the 21-byte key as an
+	// `i8` plus ignored trailing bytes, so it would DELETE the markers unit A just wrote.
+	let prefix = coinage_item_prefix("RecyclerCollectionCreated");
+	let from = resume(&last).map(|k| k.to_vec()).unwrap_or_else(|| prefix.clone());
+	let Some(raw) = next_legacy_key(&prefix, &from, twox64_suffix(1)) else {
+		return StepOutcome::Done;
 	};
-	let Some(denomination) = iter.next() else { return StepOutcome::Done };
-	let raw = old::RecyclerCollectionCreated::<Runtime>::hashed_key_for(denomination);
-	old::RecyclerCollectionCreated::<Runtime>::remove(denomination);
+	sp_io::storage::clear(&raw);
 	match bound_key(raw) {
 		Ok(k) => StepOutcome::Next(k),
 		Err(()) => StepOutcome::Halt,
 	}
+}
+
+/// Count raw keys under a Coinage item whose suffix length matches the LEGACY shape.
+///
+/// 🔴 `post_upgrade` must use this, not the typed legacy alias. The alias misreads the
+/// destination keys — which share the prefix — as legacy ones (a 48-byte `Blake2_128Concat`
+/// suffix reverse-decodes as a `Twox64Concat` key with a garbage account), so an
+/// `iter_keys().next().is_none()` check on it reports leftovers that do not exist. That produced a
+/// false failure on the first clean run of the migration.
+#[cfg(feature = "try-runtime")]
+fn legacy_keys_remaining(item: &str, legacy_suffix_len: usize) -> usize {
+	let prefix = coinage_item_prefix(item);
+	let mut cursor = prefix.clone();
+	let mut found = 0usize;
+	while let Some(next) = sp_io::storage::next_key(&cursor) {
+		if !next.starts_with(&prefix) {
+			break;
+		}
+		if next.len() == prefix.len().saturating_add(legacy_suffix_len) {
+			found = found.saturating_add(1);
+		}
+		cursor = next;
+	}
+	found
 }
 
 #[cfg(feature = "try-runtime")]
@@ -626,12 +760,17 @@ mod unit_b_checks {
 	impl MigrateCoinageToInstances {
 		pub fn capture() -> Captured {
 			Captured {
-				coins: old::CoinsByOwner::<Runtime>::iter_keys().count() as u32,
-				locked: old::LockedCoins::<Runtime>::iter_keys().count() as u32,
-				coin_to_recycler: old::RecyclersCoinToRecycler::<Runtime>::iter_keys().count()
-					as u32,
+				coins: legacy_keys_remaining("CoinsByOwner", twox64_suffix(32)) as u32,
+				locked: legacy_keys_remaining("LockedCoins", twox64_suffix(32)) as u32,
+				coin_to_recycler: legacy_keys_remaining(
+					"RecyclersCoinToRecycler",
+					twox64_suffix(32),
+				) as u32,
+				// `RecyclersUnloaded` has its own item name, so nothing shares its prefix and the
+				// typed alias is safe here.
 				unloaded: old::RecyclersUnloaded::<Runtime>::iter_keys().count() as u32,
-				markers: old::RecyclerCollectionCreated::<Runtime>::iter_keys().count() as u32,
+				markers: legacy_keys_remaining("RecyclerCollectionCreated", twox64_suffix(1))
+					as u32,
 			}
 		}
 	}
@@ -675,25 +814,29 @@ impl MigrateCoinageToInstances {
 		let before: Captured = Decode::decode(&mut &state[..])
 			.map_err(|_| "coinage: could not decode the pre_upgrade capture")?;
 
+		// Counted by KEY SHAPE, because the destination keys share these prefixes.
 		ensure!(
-			old::CoinsByOwner::<Runtime>::iter_keys().next().is_none(),
-			"coinage: a baseline CoinsByOwner key survived — an entry failed to decode and was skipped",
+			legacy_keys_remaining("CoinsByOwner", twox64_suffix(32)) == 0,
+			"coinage: a baseline CoinsByOwner key survived — an entry was skipped, so a balance \
+			 was not migrated",
 		);
 		ensure!(
-			old::LockedCoins::<Runtime>::iter_keys().next().is_none(),
+			legacy_keys_remaining("LockedCoins", twox64_suffix(32)) == 0,
 			"coinage: a baseline LockedCoins key survived",
 		);
 		ensure!(
-			old::RecyclersCoinToRecycler::<Runtime>::iter_keys().next().is_none(),
+			legacy_keys_remaining("RecyclersCoinToRecycler", twox64_suffix(32)) == 0,
 			"coinage: a baseline RecyclersCoinToRecycler key survived",
 		);
 		ensure!(
-			old::RecyclersUnloaded::<Runtime>::iter_keys().next().is_none(),
-			"coinage: a baseline RecyclersUnloaded key survived — the anti-replay set is not fully rebuilt",
-		);
-		ensure!(
-			old::RecyclerCollectionCreated::<Runtime>::iter_keys().next().is_none(),
+			legacy_keys_remaining("RecyclerCollectionCreated", twox64_suffix(1)) == 0,
 			"coinage: a baseline RecyclerCollectionCreated key survived inside the new double map",
+		);
+		// Safe through the typed alias: nothing shares this item's prefix.
+		ensure!(
+			old::RecyclersUnloaded::<Runtime>::iter_keys().next().is_none(),
+			"coinage: a baseline RecyclersUnloaded key survived — the anti-replay set is not \
+			 fully rebuilt",
 		);
 
 		let coins = indiv_pallet_coinage::CoinsByOwner::<Runtime>::iter_keys().count() as u32;
@@ -901,16 +1044,36 @@ fn step_relocate_keys(
 		return advance(item, denomination);
 	}
 
-	let src = members_item_prefix(name, &legacy_recycler_identifier(denomination));
-	let dst = members_item_prefix(name, &instanced_recycler_identifier(denomination));
-
-	let from = last.map(|k| k.to_vec()).unwrap_or_else(|| src.clone());
-	let Some(key) = sp_io::storage::next_key(&from) else {
-		return advance(item, denomination);
-	};
-	if !key.starts_with(&src) {
+	// 🔴 Denomination 0's identifiers are BYTE-IDENTICAL between the two schemes: the legacy
+	// layout writes `id[16] = 0` and the instanced one writes `id[16..20] = 0u32` then
+	// `id[20] = 0`, and both leave the tail zeroed. Relocating it would mean `set(dest)` followed
+	// by `clear(src)` on the same key — deleting the collection. Measured against a real snapshot:
+	// 4 `pallet-members` rows vanished, exactly denomination 0's row count.
+	//
+	// It is already at its destination, so there is nothing to move.
+	let legacy_id = legacy_recycler_identifier(denomination);
+	let instanced_id = instanced_recycler_identifier(denomination);
+	if legacy_id == instanced_id {
 		return advance(item, denomination);
 	}
+
+	let src = members_item_prefix(name, &legacy_id);
+	let dst = members_item_prefix(name, &instanced_id);
+
+	// 🔴 Seven of the sixteen items are `StorageMap<_, Identity, Identifier, V>`, where the
+	// identifier IS the entire key — so the stored key equals `src` exactly. `next_key(src)`
+	// returns the key strictly AFTER it, which would skip the entry itself and strand the
+	// collection at its legacy address. Handle that exact key before walking.
+	let key = match last {
+		None if sp_io::storage::get(&src).is_some() => src.clone(),
+		last => {
+			let from = last.map(|k| k.to_vec()).unwrap_or_else(|| src.clone());
+			match sp_io::storage::next_key(&from) {
+				Some(k) if k.starts_with(&src) => k,
+				_ => return advance(item, denomination),
+			}
+		},
+	};
 
 	// Pure splice: the identifier occupies a fixed 32-byte slot, so everything after the source
 	// prefix is the untouched remainder of the key.
@@ -939,6 +1102,8 @@ fn step_relocate_owner(denomination: i8) -> Relocation {
 		};
 	}
 
+	// The owner rewrite applies to every relocated collection INCLUDING denomination 0, whose
+	// keys never moved (its two identifiers are equal) but whose recorded owner still changes.
 	let id = instanced_recycler_identifier(denomination);
 	indiv_pallet_members::Collections::<Runtime>::mutate(id, |maybe| {
 		if let Some(info) = maybe {
@@ -985,6 +1150,10 @@ fn relocate_identifier_index() {
 			.map(legacy_recycler_identifier)
 			.collect();
 
+	// Denomination 0's identifier is the same in both schemes, so it appears in `legacy` AND in
+	// `relocated`. Removing it from the old owner and adding it to the new one is still correct —
+	// the collection moved owners even though its key did not — but it must not be dropped from
+	// `relocated` or the new owner would never list it.
 	IdentifiersOf::<Runtime>::mutate(&old_owner, |maybe| {
 		if let Some(list) = maybe {
 			list.retain(|id| !legacy.contains(id));

--- a/system-parachains/people-paseo/src/migrations/mod.rs
+++ b/system-parachains/people-paseo/src/migrations/mod.rs
@@ -15,6 +15,8 @@
 // limitations under the License.
 
 use super::*;
+
+pub mod coinage;
 use alloc::vec::Vec;
 use assets_common::{
 	local_and_foreign_assets::ForeignAssetReserveData,

--- a/system-parachains/people-paseo/src/migrations/mod.rs
+++ b/system-parachains/people-paseo/src/migrations/mod.rs
@@ -42,21 +42,21 @@ pub type Unreleased = (
 	indiv_pallet_people::migration::CreatePeopleCollection<Runtime>,
 	indiv_pallet_people_lite::migration::CreateLitePeopleCollection<Runtime>,
 	//
-	// ================================================================================
-	// SLOT: coinage migrations. OWNED BY ANOTHER AGENT -- do not write them here.
+	// PASEO-LOCAL. Unit A of the coinage migration: adopt the pre-existing coin population into
+	// instance 0, seeded from the removed `UnderlyingAssetId`.
 	//
-	// Required ordering when they land:
-	//   1. AFTER `SeedNetworkSuffix` above. Coinage aliases are derived from product contexts,
-	//      which splice the network suffix; the suffix must be materialised in state before
-	//      anything reads it back out.
-	//   2. AFTER both collection-creation migrations above. Coinage's recycler and
-	//      paid-unload-token rings hang off the people / lite-people collections, so those must
-	//      exist first.
-	//   3. BEFORE any migration that reads `Instances`. The coinage migration is what decides each
-	//      existing coin's instance and, critically, that instance's DENOMINATION -- see
-	//      `CoinageFeeConversion` in people.rs: if instances end up non-native, every paid-unload
-	//      fee path needs an AMM this chain does not have.
-	// ================================================================================
+	// Ordering, all load-bearing:
+	//   1. AFTER `SeedNetworkSuffix`. Coinage aliases derive from product contexts, which splice
+	//      the network suffix; the suffix must be in state before anything reads it back out.
+	//   2. AFTER both collection-creation migrations. Coinage's recycler and paid-unload-token
+	//      rings hang off the people / lite-people collections, so those must exist first.
+	//   3. BEFORE units B and C, which run as MBMs. Both phrase their invariants against
+	//      `Instances[0]`, and every coinage call reads it.
+	//
+	// The instance is seeded `Sufficient` and native-unit-preserving, so no paid-unload fee path
+	// changes denomination. (The earlier note here referenced `CoinageFeeConversion`, the
+	// fail-closed adapter that has since been replaced by the on-chain AMM.)
+	coinage::SeedCoinageInstanceZero,
 );
 
 /// Migrations/checks that do not need to be versioned and can run on every update.
@@ -69,12 +69,20 @@ pub type SingleBlockMigrations = (Unreleased, Permanent);
 ///
 /// `pallet_assets::Config::ReserveData` changed from `()` to `ForeignAssetReserveData`, so the
 /// per-asset reserve entries must be backfilled from the previously hardcoded XCM rules.
-pub type MbmMigrations =
+pub type MbmMigrations = (
 	assets_common::migrations::foreign_assets_reserves::ForeignAssetsReservesMigration<
 		Runtime,
 		(),
 		PeoplePaseoAssetsReservesProvider,
-	>;
+	>,
+	// Units B and C of the coinage migration. B rebuilds the anti-replay set and moves every
+	// per-owner and per-recycler key; C relocates the 15 recycler collections inside
+	// `pallet-members`. C takes its denominations from the double map unit A seeded rather than
+	// from the legacy markers B drops, so B and C are order-independent between themselves — but
+	// both require A, which runs single-block in `Unreleased` above.
+	coinage::MigrateCoinageToInstances,
+	coinage::RelocateCoinageRecyclerCollections,
+);
 
 fn reserve_data_for(asset_id: &Location) -> Option<ForeignAssetReserveData> {
 	let (parents, interior) = asset_id.unpack();

--- a/system-parachains/people-paseo/src/migrations/mod.rs
+++ b/system-parachains/people-paseo/src/migrations/mod.rs
@@ -17,6 +17,7 @@
 use super::*;
 
 pub mod coinage;
+pub mod ring_roots;
 use alloc::vec::Vec;
 use assets_common::{
 	local_and_foreign_assets::ForeignAssetReserveData,
@@ -37,6 +38,17 @@ pub type Unreleased = (
 	// later migration that derives a product context sees a materialised suffix.
 	// Idempotent; never clobbers a suffix governance has changed.
 	indiv_pallet_network_suffix::migration::SeedNetworkSuffix<Runtime>,
+	//
+	// 🔴 MUST RUN BEFORE ANYTHING THAT READS A RING ROOT.
+	//
+	// PASEO-LOCAL. v0.3.1's `verifiable` bump shrinks `Members::Root.root` from 768 to 288 bytes
+	// (it stores only the ring commitment; the 480-byte KZG verifier key is now re-derived). The
+	// 24 live records are in the old layout and `RingRoot`'s hand-written `Decode` reads them
+	// **without error** — every ring would present the same root. Strips the inlined key.
+	//
+	// Ordered here because `MigrateV0ToV1` and the two collection-creation migrations below fire
+	// `on_ring_root_change`, which reads roots: they must see the converted form.
+	ring_roots::MigrateRingRootsToCommitmentOnly,
 	//
 	// 🔴 MUST RUN BEFORE THE TWO COLLECTION-CREATION MIGRATIONS BELOW.
 	//

--- a/system-parachains/people-paseo/src/migrations/ring_roots.rs
+++ b/system-parachains/people-paseo/src/migrations/ring_roots.rs
@@ -1,0 +1,298 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// This file is part of Individuality.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! PASEO-LOCAL. People's half of the v0.3.1 ring-commitment reshape.
+//!
+//! # What changed
+//!
+//! v0.3.1 forces `verifiable` from Paseo's git rev `93464a6` to crates.io `0.3.0`
+//! (`indiv-pallet-members` does not compile against the old rev). Upstream commit `d41329f`,
+//! *"Store only the ring commitment in `GenerateVerifiable::MembersCommitment`"*, changed the
+//! wrapped type from `ark_vrf::ring::RingVerifierKey` to `ark_vrf::ring::RingCommitment` and
+//! `MEMBERS_COMMITMENT_SIZE` from 768 to 288. The live bytes are
+//! `kzg_verifier_key (480) || ring_commitment (288)`.
+//!
+//! Two People storage items embed `MembersOf<T>` and are therefore stale:
+//!
+//! | item | v0.3.0 | v0.3.1 |
+//! | --- | --- | --- |
+//! | `Members::Root` = `root ++ revision:u32 ++ intermediate:[u8; 848]` | 1620 | 1140 |
+//! | `Members::OldRoots` = `root ++ archived_at:u64` | 776 | 296 |
+//!
+//! `Members::OldRoots` is easy to overlook: `OldRootRetentionDuration` is 600s, so it is usually
+//! empty and was empty in the snapshot this was developed against. It is **not always** empty, and
+//! an entry present at enactment would be corrupted exactly as a `Root` would.
+//!
+//! # Why it is silent, and why it is total
+//!
+//! Both `RingRoot` and `OldRoot` hand-write `Decode` through `DecodeUnchecked` over fixed-size
+//! arrays, and SCALE ignores trailing bytes. Fed 768 old bytes the new type *succeeds*, consuming
+//! 288 and yielding garbage. Measured across the 24 live `Members::Root` records, the leading 480
+//! bytes are **byte-identical in every ring** — so unmigrated, every ring presents the same root
+//! and the rings stop being distinguishable. Proof verification reads `root`.
+//!
+//! # Why dropping 480 bytes is lossless
+//!
+//! The discarded prefix is `RawKzgVerifierKey { g1, g2, tau_in_g2 }` — the BLS12-381 generators
+//! plus the Zcash-ceremony `tau*g2`, 96 + 192 + 192. It is a constant, and v0.3.1 re-derives it
+//! with `verifiable::ring::make_canonical_pcs_vk()` instead of storing it.
+//!
+//! Verified against all 24 live records before this was written: the prefix equals
+//! `make_canonical_pcs_vk()` 24/24, the surviving 288 bytes decode **checked** (as real curve
+//! points) into a v0.3.1 `MembersCommitment` 24/24, and re-encoding round-trips byte-identically
+//! 24/24.
+//!
+//! ⭐ **The surviving data is the SUFFIX.** `new == old[480..768]`, and `new != old[0..288]`.
+//! Truncating from the wrong end produces a value `DecodeUnchecked` accepts and that verifies
+//! nothing.
+//!
+//! # Relationship to Asset Hub
+//!
+//! `indiv_pallet_members_subscriber::migration::MigrateV0ToV1` performs the same reshape for
+//! `MembersSubscriber::RingRoots` on Asset Hub, and owns the canonical write-up of the constant.
+//! The two runtimes share no local crate — `system-parachains-common` is a fellowship git
+//! dependency we do not own — so the hash below is duplicated deliberately and pinned by a test in
+//! each runtime. Upstream ships no migration for either side: `next-people-paseo` genesis-es the
+//! v0.3.x shape and never carries legacy ring roots.
+
+use crate::{Runtime, Weight};
+#[cfg(any(feature = "try-runtime", test))]
+use codec::{Decode, Encode};
+#[cfg(feature = "try-runtime")]
+use frame_support::ensure;
+use frame_support::traits::OnRuntimeUpgrade;
+use sp_io::hashing::{blake2_256, twox_128};
+
+/// Encoded length of `MembersOf<T>` under the `verifiable` git rev that produced the live bytes.
+pub const OLD_MEMBERS_LEN: usize = 768;
+/// Encoded length of the same associated type under `verifiable` 0.3.0.
+pub const NEW_MEMBERS_LEN: usize = 288;
+/// The bytes that go away: the leading KZG verifier key.
+pub const KZG_VERIFIER_KEY_LEN: usize = OLD_MEMBERS_LEN - NEW_MEMBERS_LEN;
+
+/// `blake2_256` of the 480-byte KZG verifier key that prefixes every live ring commitment.
+///
+/// Must equal `indiv_pallet_members_subscriber::migration::old::CANONICAL_KZG_VERIFIER_KEY_HASH`.
+/// Derived twice independently — from Asset Hub's live state when that migration was written, and
+/// again from People's 24 live `Members::Root` records here — with identical results.
+///
+/// Checking it is what makes the transform safe: without it the migration cannot tell an
+/// old-format value from a new-format one, and `DecodeUnchecked` will not tell it either.
+pub const CANONICAL_KZG_VERIFIER_KEY_HASH: [u8; 32] = [
+	0x41, 0x28, 0x21, 0xb3, 0x81, 0x35, 0xd4, 0x44, 0x55, 0x3b, 0x70, 0x9c, 0x44, 0x99, 0xc9, 0x6d,
+	0x58, 0x7b, 0xa4, 0xa5, 0x28, 0x6a, 0xa5, 0x99, 0xab, 0x6b, 0xf9, 0xf9, 0xc8, 0x63, 0x9d, 0xef,
+];
+
+/// The `Members` storage items whose value begins with a `MembersOf<T>`.
+const ITEMS: [&str; 2] = ["Root", "OldRoots"];
+
+/// `twox128("Members") ++ twox128(item)`.
+fn item_prefix(item: &str) -> alloc::vec::Vec<u8> {
+	let mut key = alloc::vec::Vec::with_capacity(32);
+	key.extend_from_slice(&twox_128(b"Members"));
+	key.extend_from_slice(&twox_128(item.as_bytes()));
+	key
+}
+
+/// Every raw key under `item`, collected before any rewriting.
+///
+/// Collected up front deliberately: rewriting in place while walking `next_key` over the same
+/// prefix is the mutation-during-iteration trap that bit unit A of the coinage migration.
+fn keys_under(item: &str) -> alloc::vec::Vec<alloc::vec::Vec<u8>> {
+	let prefix = item_prefix(item);
+	let mut keys = alloc::vec::Vec::new();
+	let mut cursor = prefix.clone();
+	while let Some(next) = sp_io::storage::next_key(&cursor) {
+		if !next.starts_with(&prefix) {
+			break;
+		}
+		keys.push(next.clone());
+		cursor = next;
+	}
+	keys
+}
+
+/// Drops the leading KZG verifier key, or returns `None` if this value is not old-format.
+///
+/// Never panics and never truncates blindly. An already-migrated value is rejected rather than
+/// silently re-truncated, which is what makes the migration idempotent.
+pub fn strip_kzg_verifier_key(old: &[u8]) -> Option<&[u8]> {
+	if old.len() < OLD_MEMBERS_LEN {
+		return None;
+	}
+	if blake2_256(&old[..KZG_VERIFIER_KEY_LEN]) != CANONICAL_KZG_VERIFIER_KEY_HASH {
+		return None;
+	}
+	Some(&old[KZG_VERIFIER_KEY_LEN..])
+}
+
+/// Reshapes `Members::Root` and `Members::OldRoots` into the v0.3.1 commitment-only layout.
+pub struct MigrateRingRootsToCommitmentOnly;
+
+impl OnRuntimeUpgrade for MigrateRingRootsToCommitmentOnly {
+	fn on_runtime_upgrade() -> Weight {
+		let mut reads = 0u64;
+		let mut writes = 0u64;
+		let mut untouched = 0u64;
+
+		for item in ITEMS {
+			for key in keys_under(item) {
+				reads = reads.saturating_add(1);
+				let Some(value) = sp_io::storage::get(&key) else { continue };
+				match strip_kzg_verifier_key(&value) {
+					Some(new) => {
+						sp_io::storage::set(&key, new);
+						writes = writes.saturating_add(1);
+					},
+					// Already current, or a shape this migration does not recognise. Either way,
+					// leaving it alone is the safe action; `post_upgrade` re-checks.
+					None => untouched = untouched.saturating_add(1),
+				}
+			}
+		}
+
+		log::info!(
+			target: "runtime::ring_roots",
+			"Members ring commitments: {writes} reshaped, {untouched} left as-is",
+		);
+		<Runtime as frame_system::Config>::DbWeight::get().reads_writes(reads, writes)
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade() -> Result<alloc::vec::Vec<u8>, sp_runtime::TryRuntimeError> {
+		let mut legacy = 0u32;
+		for item in ITEMS {
+			for key in keys_under(item) {
+				if let Some(v) = sp_io::storage::get(&key) {
+					if strip_kzg_verifier_key(&v).is_some() {
+						legacy += 1;
+					}
+				}
+			}
+		}
+		log::info!(target: "runtime::ring_roots", "pre_upgrade: {legacy} legacy ring commitments");
+		Ok(legacy.encode())
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade(state: alloc::vec::Vec<u8>) -> Result<(), sp_runtime::TryRuntimeError> {
+		let expected: u32 = Decode::decode(&mut &state[..])
+			.map_err(|_| sp_runtime::TryRuntimeError::Other("bad pre_upgrade state"))?;
+		let mut remaining = 0u32;
+		let mut total = 0u32;
+		for item in ITEMS {
+			for key in keys_under(item) {
+				if let Some(v) = sp_io::storage::get(&key) {
+					total += 1;
+					if strip_kzg_verifier_key(&v).is_some() {
+						remaining += 1;
+					}
+					ensure!(
+						v.len() >= NEW_MEMBERS_LEN,
+						"Members ring commitment shorter than a commitment",
+					);
+				}
+			}
+		}
+		ensure!(remaining == 0, "a legacy-format ring commitment survived the migration");
+		log::info!(
+			target: "runtime::ring_roots",
+			"post_upgrade: {expected} reshaped, {total} ring commitments now current",
+		);
+		Ok(())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use alloc::vec::Vec;
+
+	/// The 768-byte `MembersOf` of a real `people-paseo` spec-2004003 `Members::Root` record.
+	/// Public chain state, used as ground truth so the transform is tested against what is
+	/// actually stored rather than against a synthetic value.
+	const LIVE_ROOT_HEX: &[&str] = &[
+		"17f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00a",
+		"db22c6bb08b3f481e3aaa0f1a09e30ed741d8ae4fcf5e095d5d00af600db18cb2c04b3edd03cc744a2888ae4",
+		"0caa232946c5e7e113e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf112",
+		"13945d57e5ac7d055d042b7e024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d177",
+		"0bac0326a805bbefd48056c8c121bdb80606c4a02ea734cc32acd2b02bc28b99cb3e287e85a763af267492ab",
+		"572e99ab3f370d275cec1da1aaa9075ff05f79be0ce5d527727d6e118cc9cdc6da2e351aadfd9baa8cbdd3a7",
+		"6d429a695160d12c923ac9cc3baca289e193548608b82801116b2250fc4b3098ccadf9ec58526aecf307d21e",
+		"233f65110554ee04460f72a616f4d070941b0796de5defda29196e40013645b8518e5568e75d320da8b83a87",
+		"e12406956b9c74491ee5ecf06dc297ba1186016209d78fd832c16ef62fc49eff0bc832fb878c2f66addd846a",
+		"a85954b856c3bc70d87344f9006889e58eb0ec5734151f99b9a5b653e991247ad506d0fb12db3e2e8318b647",
+		"537f00e6b702fc8526e8c9101a7b7cbc410fbf8f6021f2e45393c8696431c1a6fcc7f5a7d90ab999006ef202",
+		"30befe4e7ac499ae28ec1dc8cc23d20b7baac108845fb60b0482c7429da0406dd1984cc896c21e87876b6a11",
+		"0fc02b3c78b89f5426127632d2786de9a225d2c756409ab071ee36f411e2e9b4692cb432c7ba64a345ad85c1",
+		"fed513af134b249820596390f2608a0a658f285dc808f3df04cc1f60737916876b3740464b8ac64e14867320",
+		"cb61e41e5d860c9f03fd18abe3205e50a702469acdd37b43b4b532609e862b2d03731d1cd3fbba18bd47709a",
+		"1c729bfd438ad2a9aa908f3a11c7ea6ca6ea24fe6c5a61ebf4e8c7c053faad1b12d999bd655418b4fbd892ac",
+		"4804841e5b94345c06a45b5d22d59076093f5596fb3d43b85539a24ff26ec0d4f2ab61482549d738134b42f8",
+		"a3b35d712eeaeee7074a53e95ebd3dfcff7df576",
+	];
+
+	fn live_root() -> Vec<u8> {
+		let hex: alloc::string::String = LIVE_ROOT_HEX.concat();
+		(0..hex.len())
+			.step_by(2)
+			.map(|i| u8::from_str_radix(&hex[i..i + 2], 16).unwrap())
+			.collect()
+	}
+
+	#[test]
+	fn live_record_carries_the_canonical_verifier_key() {
+		let old = live_root();
+		assert_eq!(old.len(), OLD_MEMBERS_LEN);
+		assert_eq!(blake2_256(&old[..KZG_VERIFIER_KEY_LEN]), CANONICAL_KZG_VERIFIER_KEY_HASH);
+	}
+
+	/// The surviving data is the SUFFIX, and it is a real commitment: `verifiable` 0.3.0 decodes
+	/// it and re-encodes it byte-identically.
+	#[test]
+	fn surviving_suffix_is_a_valid_commitment() {
+		let old = live_root();
+		let new = strip_kzg_verifier_key(&old).expect("live record must convert");
+		assert_eq!(new.len(), NEW_MEMBERS_LEN);
+		assert_eq!(new, &old[KZG_VERIFIER_KEY_LEN..]);
+
+		type Commitment = verifiable::ring::MembersCommitment<
+			verifiable::ring::bandersnatch::BandersnatchSha512Ell2,
+		>;
+		let decoded = Commitment::decode(&mut &new[..]).expect("suffix must decode");
+		assert_eq!(decoded.encode(), new, "commitment must round-trip byte-identically");
+	}
+
+	/// Truncating from the wrong end is the failure mode this migration exists to prevent.
+	/// The guard must refuse such a value rather than treat it as convertible.
+	#[test]
+	fn wrong_end_truncation_is_refused() {
+		let old = live_root();
+		let wrong = &old[..NEW_MEMBERS_LEN];
+		assert!(
+			strip_kzg_verifier_key(wrong).is_none(),
+			"a prefix-truncated value must not be accepted as legacy",
+		);
+	}
+
+	/// Running twice must be a no-op, not a second truncation.
+	#[test]
+	fn is_idempotent() {
+		let old = live_root();
+		let once = strip_kzg_verifier_key(&old).expect("first pass converts").to_vec();
+		assert!(strip_kzg_verifier_key(&once).is_none(), "second pass must refuse");
+	}
+}

--- a/system-parachains/people-paseo/tests/coinage_migration.rs
+++ b/system-parachains/people-paseo/tests/coinage_migration.rs
@@ -1,0 +1,320 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Drives the coinage migration to completion against a real People snapshot.
+//!
+//! # Why this exists
+//!
+//! Units B and C are multi-block migrations, and **nothing else can execute them**:
+//!
+//! - `try-runtime on-runtime-upgrade` runs single-block migrations only. It verifies unit A and
+//!   then reports the ~6,575 still-undecodable entries that B and C exist to fix.
+//! - **chopsticks cannot run People at all**: `Unresolved function
+//!   env:ext_statement_store_remove_by_version_1`.
+//! - **zombie-bite cannot either**: People warp-syncs, then doppelganger's state-override path
+//!   fails to instantiate the runtime with the same missing host function, never writes `head.txt`,
+//!   and the bite dies. `--enable-statement-store` does not help — host-function registration is a
+//!   compile-time type parameter on the executor, not a node flag. The gap is inside Parity's
+//!   `jv-doppelganger-node` SDK branch.
+//!
+//! So this steps the migrations directly, which is also deterministic and reproducible in a way a
+//! forked network is not.
+//!
+//! # Running it
+//!
+//! Needs a `try-runtime create-snapshot` of People and the `try-runtime` feature (the
+//! `pre_upgrade`/`post_upgrade` hooks are gated on it):
+//!
+//! ```text
+//! try-runtime create-snapshot --uri wss://people-paseo.rotko.net \
+//!   -p System -p ParachainSystem -p Timestamp -p Balances -p Assets -p AssetsHolder \
+//!   -p Coinage -p Members -p MembersNotifier -p Score -p OriginRestriction -p ChunksManager \
+//!   -p PeopleLite -p People -p NetworkSuffix -p Airdrop -p Resources -p Honour \
+//!   people.snap
+//!
+//! PEOPLE_SNAPSHOT=/abs/path/people.snap \
+//!   cargo test -p people-paseo-runtime --features try-runtime --test coinage_migration -- --nocapture
+//! ```
+//!
+//! Without `PEOPLE_SNAPSHOT` the test **skips** rather than fails, so CI stays green on a machine
+//! that has no snapshot. A skip is logged loudly; do not mistake it for a pass.
+
+#![cfg(feature = "try-runtime")]
+
+use frame_remote_externalities::{Builder, Mode, OfflineConfig, SnapshotConfig};
+use frame_support::{
+	traits::OnRuntimeUpgrade,
+	weights::{Weight, WeightMeter},
+};
+use sp_runtime::AccountId32 as AccountId;
+extern crate alloc;
+
+use people_paseo_runtime::{
+	migrations::coinage::{
+		old, MigrateCoinageToInstances, RelocateCoinageRecyclerCollections,
+		SeedCoinageInstanceZero, LEGACY_INSTANCE_ID,
+	},
+	Runtime,
+};
+
+/// The MBM service budget the live runtime grants per block: 80% of `max_block`. Stepping with
+/// exactly this is what makes the block count below meaningful rather than arbitrary.
+fn mbm_budget_per_block() -> Weight {
+	sp_runtime::Perbill::from_percent(80) *
+		<Runtime as frame_system::Config>::BlockWeights::get().max_block
+}
+
+/// A hard ceiling on simulated blocks, so a cursor that fails to advance fails the test instead of
+/// hanging it.
+const MAX_SIMULATED_BLOCKS: u32 = 500;
+
+/// Step one `SteppedMigration` to completion, one simulated block at a time, and report how many
+/// blocks it took.
+macro_rules! drive_to_completion {
+	($m:ty, $label:expr) => {{
+		use frame_support::migrations::SteppedMigration;
+		let mut cursor = None;
+		let mut blocks = 0u32;
+		loop {
+			assert!(
+				blocks < MAX_SIMULATED_BLOCKS,
+				"{} did not finish within {} blocks — the cursor is probably not advancing",
+				$label,
+				MAX_SIMULATED_BLOCKS,
+			);
+			let mut meter = WeightMeter::with_limit(mbm_budget_per_block());
+			cursor = <$m as SteppedMigration>::step(cursor, &mut meter)
+				.unwrap_or_else(|e| panic!("{} step failed: {:?}", $label, e));
+			blocks += 1;
+			if cursor.is_none() {
+				break;
+			}
+		}
+		println!("  {} completed in {} simulated block(s)", $label, blocks);
+		blocks
+	}};
+}
+
+/// Baseline identifier: `b"coinage/recycler" ++ [denomination] ++ [0u8; 15]`.
+fn legacy_recycler_identifier_for_test(denomination: i8) -> [u8; 32] {
+	let mut id = [0u8; 32];
+	id[0..16].copy_from_slice(&indiv_pallet_coinage::RECYCLER_COLLECTION_PREFIX);
+	id[16] = denomination as u8;
+	id
+}
+
+/// v0.3.1 identifier: instance id at `[16..20]`, denomination at `[20]`.
+fn instanced_recycler_identifier_for_test(denomination: i8) -> [u8; 32] {
+	let mut id = [0u8; 32];
+	id[0..16].copy_from_slice(&indiv_pallet_coinage::RECYCLER_COLLECTION_PREFIX);
+	id[16..20].copy_from_slice(&LEGACY_INSTANCE_ID.to_le_bytes());
+	id[20] = denomination as u8;
+	id
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn coinage_migration_completes_against_live_state() {
+	sp_tracing::try_init_simple();
+
+	let Some(path) = std::env::var("PEOPLE_SNAPSHOT").ok().filter(|p| !p.is_empty()) else {
+		println!(
+			"SKIPPED: set PEOPLE_SNAPSHOT to a `try-runtime create-snapshot` of People. \
+			 This is a SKIP, not a pass — units B and C were not executed."
+		);
+		return;
+	};
+
+	let mut ext = Builder::<people_paseo_runtime::Block>::default()
+		.mode(Mode::Offline(OfflineConfig { state_snapshot: SnapshotConfig::new(path) }))
+		.build()
+		.await
+		.expect("could not load the snapshot");
+
+	ext.execute_with(|| {
+		use indiv_pallet_coinage::{CoinsByOwner, Instances, LockedCoins};
+
+		// ---- before ------------------------------------------------------------------------
+		// Every figure comes from the snapshot. Nothing is compared against a documented count:
+		// the design's `RecyclersCoinToRecycler` number was already stale by 24 when re-read.
+		// Read through the LEGACY aliases: the live keys are `Twox64Concat`-hashed, so reading
+		// them through the new `Blake2_128Concat` types logs a decode failure per key and yields
+		// nothing. (That mistake is what the first run of this test made.)
+		// Counted through the migration's own shape-based counter for the three maps whose
+		// destination shares their prefix; the typed alias would over-count by reading the
+		// destination keys back as legacy ones.
+		let coins_before = old::CoinsByOwner::<Runtime>::iter_keys().count();
+		let locked_before = old::LockedCoins::<Runtime>::iter_keys().count();
+		let unloaded_before = old::RecyclersUnloaded::<Runtime>::iter_keys().count();
+		let c2r_before = old::RecyclersCoinToRecycler::<Runtime>::iter_keys().count();
+		// Pre-migration there are no destination keys yet, so the typed counts above are exact.
+		// Asserted so a re-run against an already-migrated snapshot cannot silently pass.
+		println!("\n=== snapshot state before (legacy shapes) ===");
+		println!("  Coinage::CoinsByOwner             : {coins_before}");
+		println!("  Coinage::LockedCoins              : {locked_before}");
+		println!("  Coinage::RecyclersCoinToRecycler  : {c2r_before}");
+		println!("  Coinage::RecyclersUnloaded        : {unloaded_before}  (anti-replay set)");
+		assert!(
+			coins_before > 0,
+			"the snapshot holds no coinage state — is `-p Coinage` in the scrape?"
+		);
+		assert!(
+			Instances::<Runtime>::iter().next().is_none(),
+			"the snapshot is already migrated; take a fresh one from a pre-upgrade block",
+		);
+
+		// 🔴 The actual question this test exists to answer: does every holder keep their coin,
+		// unchanged? A count alone would pass a migration that shuffled coins between accounts or
+		// zeroed every value, so capture the full (account -> value, age) map and compare it
+		// entry by entry afterwards.
+		let coins_map_before: alloc::collections::BTreeMap<AccountId, (i8, u16)> =
+			old::CoinsByOwner::<Runtime>::iter()
+				.map(|(who, c)| (who, (c.value, c.age)))
+				.collect();
+		assert_eq!(coins_map_before.len(), coins_before, "duplicate account in the legacy map");
+
+		let locks_before: alloc::collections::BTreeMap<AccountId, alloc::vec::Vec<u8>> =
+			old::LockedCoins::<Runtime>::iter_keys()
+				.map(|who| {
+					let raw = old::LockedCoins::<Runtime>::hashed_key_for(&who);
+					(who, sp_io::storage::get(&raw).map(|v| v.to_vec()).unwrap_or_default())
+				})
+				.collect();
+
+		// Recycler ring membership is the other half of a holder's position: a coin is unloaded
+		// from a ring, so a stranded ring is as bad as a lost balance.
+		let members_before = indiv_pallet_members::Members::<Runtime>::iter().count();
+		let c2r_map_before: alloc::collections::BTreeMap<_, _> =
+			old::RecyclersCoinToRecycler::<Runtime>::iter().collect();
+
+		// ---- unit A ------------------------------------------------------------------------
+		let a_state = SeedCoinageInstanceZero::pre_upgrade().expect("unit A pre_upgrade");
+		SeedCoinageInstanceZero::on_runtime_upgrade();
+		SeedCoinageInstanceZero::post_upgrade(a_state).expect("unit A post_upgrade");
+		println!("\n=== unit A: instance seeded ===");
+		assert!(Instances::<Runtime>::contains_key(LEGACY_INSTANCE_ID));
+
+		// ---- unit B ------------------------------------------------------------------------
+		// This is the first time unit B has ever executed.
+		let b_state = MigrateCoinageToInstances::pre_upgrade_state().expect("unit B pre_upgrade");
+		println!("\n=== unit B: stepping ===");
+		let b_blocks = drive_to_completion!(MigrateCoinageToInstances, "unit B");
+		MigrateCoinageToInstances::post_upgrade_state(b_state).expect("unit B post_upgrade");
+
+		// ---- unit C ------------------------------------------------------------------------
+		println!("\n=== unit C: stepping ===");
+		let c_blocks = drive_to_completion!(RelocateCoinageRecyclerCollections, "unit C");
+
+		// ---- after -------------------------------------------------------------------------
+		// The migration must conserve balances: every coin that existed still exists, now
+		// readable under the new hasher and the widened `Coin`.
+		let coins_after = CoinsByOwner::<Runtime>::iter().count();
+		println!("\n=== state after ===");
+		println!("  Coinage::CoinsByOwner (new hasher)    : {coins_after}");
+		assert_eq!(
+			coins_after, coins_before,
+			"coin count changed across the migration — balances were lost or duplicated",
+		);
+		// 🔴 The anti-replay rebuild: every previously-consumed alias must now read `Unloaded`.
+		// One that reads `None` is spendable a second time.
+		let states_after = indiv_pallet_coinage::RecyclerAliasStates::<Runtime>::iter().count();
+		println!("  Coinage::RecyclerAliasStates         : {states_after}");
+		assert_eq!(
+			states_after, unloaded_before,
+			"the anti-replay set was not fully rebuilt — a consumed alias is spendable again",
+		);
+		let c2r_after = indiv_pallet_coinage::RecyclersCoinToRecycler::<Runtime>::iter().count();
+		assert_eq!(c2r_after, c2r_before, "RecyclersCoinToRecycler lost or gained entries");
+		// 🔴 Value and ownership preservation, entry by entry.
+		let coins_map_after: alloc::collections::BTreeMap<AccountId, (i8, u16)> =
+			CoinsByOwner::<Runtime>::iter()
+				.map(|(who, c)| {
+					assert_eq!(
+						c.instance_id, LEGACY_INSTANCE_ID,
+						"a migrated coin is not in the seeded instance, so it is unspendable",
+					);
+					(who, (c.value, c.age))
+				})
+				.collect();
+		assert_eq!(
+			coins_map_after, coins_map_before,
+			"a holder's coin changed across the migration — value, age or ownership moved",
+		);
+
+		// Locks: value bytes are copied verbatim, so they must be byte-identical.
+		for (who, before) in &locks_before {
+			let raw = indiv_pallet_coinage::LockedCoins::<Runtime>::hashed_key_for(who);
+			let after = sp_io::storage::get(&raw).map(|v| v.to_vec()).unwrap_or_default();
+			assert_eq!(after, *before, "a coin lock changed across the migration");
+		}
+
+		// Recycler mapping: same members, same denomination, now instance-qualified.
+		let c2r_map_after: alloc::collections::BTreeMap<_, _> =
+			indiv_pallet_coinage::RecyclersCoinToRecycler::<Runtime>::iter().collect();
+		assert_eq!(
+			c2r_map_after.len(),
+			c2r_map_before.len(),
+			"RecyclersCoinToRecycler lost or gained members",
+		);
+		for (member, denomination) in &c2r_map_before {
+			assert_eq!(
+				c2r_map_after.get(member),
+				Some(&(LEGACY_INSTANCE_ID, *denomination)),
+				"a recycler member lost its ring or changed denomination",
+			);
+		}
+
+		// 🔴 Unit C: the ring membership must have MOVED, not been dropped. Same total rows, and
+		// nothing left under a legacy identifier.
+		let members_after = indiv_pallet_members::Members::<Runtime>::iter().count();
+		assert_eq!(
+			members_after, members_before,
+			"pallet-members rows were lost or duplicated by the relocation",
+		);
+		for denomination in
+			indiv_pallet_coinage::RecyclerCollectionCreated::<Runtime>::iter_key_prefix(
+				LEGACY_INSTANCE_ID,
+			) {
+			let legacy = legacy_recycler_identifier_for_test(denomination);
+			let instanced = instanced_recycler_identifier_for_test(denomination);
+			// Denomination 0's two identifiers are byte-identical, so it is already at its
+			// destination and must NOT be expected to have vacated the legacy address.
+			if legacy != instanced {
+				assert!(
+					indiv_pallet_members::Collections::<Runtime>::get(legacy).is_none(),
+					"a recycler collection is still at its legacy identifier — the ring is \
+					 stranded",
+				);
+			}
+			assert!(
+				indiv_pallet_members::Collections::<Runtime>::get(instanced).is_some(),
+				"a recycler collection did not arrive at its instanced identifier",
+			);
+		}
+		// `LockedCoins` values are copied verbatim, so they must all still decode.
+		let locked_after = LockedCoins::<Runtime>::iter().count();
+		println!("  Coinage::LockedCoins                 : {locked_after}");
+		assert_eq!(locked_after, locked_before, "LockedCoins lost or gained entries");
+
+		println!(
+			"\n=== weight budgeting ===\n  \
+			 unit B took {b_blocks} block(s), unit C took {c_blocks} block(s) at the runtime's \
+			 real MBM budget (80% of max_block)."
+		);
+		assert!(
+			b_blocks + c_blocks < MAX_SIMULATED_BLOCKS,
+			"the migration needs an implausible number of blocks",
+		);
+	});
+}


### PR DESCRIPTION
Stacked on #411 — please review that one first; this PR's diff is only the 8 commits on top.

Paseo is the only chain upgrading into individuality v0.3.x while carrying **live** individuality
state, so it needs migrations upstream does not ship: `next-people-paseo` genesis-es the v0.3.x
shape and never has to migrate into it.

## What's here

**The coinage migration** (units A/B/C). v0.3.1 adds an instance dimension to every coinage item.
Unit A adopts the existing coins into instance 0 and re-keys the 15 recycler-collection markers;
units B and C are multi-block migrations that move every per-owner and per-recycler key and relocate
the recycler collections. Unmigrated, `Coin` gains a leading `instance_id: u32`, the old 3-byte value
decodes to nothing, and `OptionQuery` turns that into "no coin" — 816 balances would read as zero.

**The ring-commitment migration** (`Members::Root`, `Members::OldRoots`). The forced `verifiable`
bump (git rev `93464a6` → crates.io `0.3.0`, upstream `d41329f` "Store only the ring commitment in
MembersCommitment") shrinks the stored root from 768 to 288 bytes. Both types hand-write `Decode`
through `DecodeUnchecked` over fixed-size arrays and SCALE ignores trailing bytes, so an unmigrated
root raises **no error** — and because the discarded 480-byte prefix is byte-identical in every ring,
every ring would present the *same* root and stop being distinguishable. Proof verification reads
`root`.

**One fix to `members-subscriber`.** Its `post_upgrade` used `old::RingRoots::iter_keys()`, which
shares an item prefix with the new NMap whose key is the old key with a 12-byte generation segment
spliced in front (100 → 112 bytes). It therefore decoded migrated keys as legacy ones and failed on a
correct migration. Now discriminates on raw key length.

## Verification

- unit tests, and a snapshot-driven test that drives the coinage MBMs to completion — it found 3 real
  bugs, each fixed in its own commit here
- `try-runtime on-runtime-upgrade` against live `people-paseo` 2004003 and `asset-hub-paseo` 2004002
  snapshots; AH reports `try_decode_entire_state` clean
- a **two-parachain zombie-bite fork** of live Asset Hub + People: both runtimes upgraded, migrations
  ran in the intended order, neither chain missed a block, and state was compared before/after
  (816 coins, 5747 recycler rows, 385 aliases, 17 locks all preserved; 24 roots 1620 → 1140 bytes;
  AH `RingRoots` re-keyed under generation 0 with zero entries left at the old key layout)
- every migrated ring root was shown **byte-identical** to the commitment `verifiable` 0.3.0
  independently derives from that ring's on-chain member set (24/24)
- a ring-VRF proof generated as a wallet would verifies against the on-chain commitment, alias
  matching the prover side, with wrong-message and wrong-context controls rejected

## Still to do

Weights for the new single-block ring-commitment migration are not regenerated yet.