### PR TITLE
feat(relay): align Paseo with Fellowship v2.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,7 +257,7 @@ dependencies = [
  "ruint",
  "rustc-hash 2.1.1",
  "serde",
- "sha3",
+ "sha3 0.10.8",
 ]
 
 [[package]]
@@ -320,7 +320,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "sha3",
+ "sha3 0.10.8",
  "syn 2.0.117",
  "syn-solidity",
 ]
@@ -1168,7 +1168,7 @@ dependencies = [
  "ark-serialize 0.6.0",
  "ark-std 0.6.0",
  "digest 0.10.7",
- "sha3",
+ "sha3 0.10.8",
 ]
 
 [[package]]
@@ -1257,7 +1257,7 @@ dependencies = [
  "asn1-rs-derive 0.5.1",
  "asn1-rs-impl",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-traits",
  "rusticata-macros",
  "thiserror 1.0.69",
@@ -1273,7 +1273,7 @@ dependencies = [
  "asn1-rs-derive 0.6.0",
  "asn1-rs-impl",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-traits",
  "rusticata-macros",
  "thiserror 2.0.18",
@@ -1369,7 +1369,7 @@ dependencies = [
  "frame-election-provider-support",
  "frame-executive",
  "frame-metadata-hash-extension",
- "frame-remote-externalities",
+ "frame-remote-externalities 0.60.0",
  "frame-support",
  "frame-system",
  "frame-system-benchmarking",
@@ -1422,16 +1422,16 @@ dependencies = [
  "pallet-pgas-allowance",
  "pallet-preimage",
  "pallet-proxy",
- "pallet-rc-migrator",
+ "pallet-rc-migrator 0.1.0 (git+https://github.com/polkadot-fellows/runtimes?tag=v2.4.0)",
  "pallet-referenda",
  "pallet-revive",
  "pallet-scheduler",
  "pallet-session",
  "pallet-staking",
- "pallet-staking-async",
+ "pallet-staking-async 0.14.0",
  "pallet-staking-async-rc-client",
  "pallet-staking-runtime-api",
- "pallet-state-trie-migration",
+ "pallet-state-trie-migration 55.0.0",
  "pallet-sudo",
  "pallet-timestamp",
  "pallet-transaction-payment",
@@ -1454,7 +1454,7 @@ dependencies = [
  "polkadot-core-primitives",
  "polkadot-parachain-primitives",
  "polkadot-primitives",
- "polkadot-runtime-common",
+ "polkadot-runtime-common 29.0.0",
  "primitive-types 0.13.1",
  "scale-info",
  "serde_json",
@@ -2321,7 +2321,7 @@ dependencies = [
  "paseo-runtime-constants",
  "polkadot-core-primitives",
  "polkadot-parachain-primitives",
- "polkadot-runtime-common",
+ "polkadot-runtime-common 29.0.0",
  "scale-info",
  "serde",
  "serde_json",
@@ -2525,7 +2525,7 @@ dependencies = [
  "parity-scale-codec",
  "paseo-runtime-constants",
  "polkadot-parachain-primitives",
- "polkadot-runtime-common",
+ "polkadot-runtime-common 29.0.0",
  "scale-info",
  "serde",
  "serde_json",
@@ -2730,13 +2730,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "chacha20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.1",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chacha20poly1305"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher 0.4.4",
  "poly1305",
  "zeroize",
@@ -2901,7 +2912,7 @@ dependencies = [
  "paseo-runtime-constants",
  "polkadot-core-primitives",
  "polkadot-parachain-primitives",
- "polkadot-runtime-common",
+ "polkadot-runtime-common 29.0.0",
  "scale-info",
  "serde_json",
  "sp-api",
@@ -3141,7 +3152,7 @@ dependencies = [
  "paseo-runtime",
  "paseo-runtime-constants",
  "paseo-system-emulated-network",
- "polkadot-runtime-common",
+ "polkadot-runtime-common 29.0.0",
  "polkadot-runtime-parachains",
  "sp-runtime",
  "staging-xcm",
@@ -3194,7 +3205,7 @@ dependencies = [
  "paseo-runtime-constants",
  "polkadot-core-primitives",
  "polkadot-parachain-primitives",
- "polkadot-runtime-common",
+ "polkadot-runtime-common 29.0.0",
  "scale-info",
  "serde",
  "serde_json",
@@ -3671,7 +3682,7 @@ dependencies = [
  "frame-system",
  "pallet-message-queue",
  "parity-scale-codec",
- "polkadot-runtime-common",
+ "polkadot-runtime-common 29.0.0",
  "polkadot-runtime-parachains",
  "scale-info",
  "sp-core",
@@ -3766,7 +3777,7 @@ dependencies = [
  "log",
  "pallet-asset-conversion",
  "parity-scale-codec",
- "polkadot-runtime-common",
+ "polkadot-runtime-common 29.0.0",
  "sp-runtime",
  "staging-xcm",
  "staging-xcm-builder",
@@ -3993,6 +4004,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
+ "der_derive",
+ "flagset",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -4005,7 +4018,7 @@ checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
 dependencies = [
  "asn1-rs 0.6.2",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-bigint",
  "num-traits",
  "rusticata-macros",
@@ -4019,10 +4032,21 @@ checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
 dependencies = [
  "asn1-rs 0.7.1",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-bigint",
  "num-traits",
  "rusticata-macros",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4163,6 +4187,21 @@ dependencies = [
  "block-buffer 0.12.1",
  "const-oid 0.10.2",
  "crypto-common 0.2.2",
+]
+
+[[package]]
+name = "dimpl"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fa936d6931067b24f3467ae6d1747a7985b5713aec477aacea2d1d8995234e8"
+dependencies = [
+ "arrayvec",
+ "log",
+ "nom 8.0.0",
+ "once_cell",
+ "rand 0.9.2",
+ "subtle 2.6.1",
+ "time",
 ]
 
 [[package]]
@@ -4358,6 +4397,7 @@ dependencies = [
  "ff",
  "generic-array 0.14.7",
  "group",
+ "pem-rfc7468",
  "pkcs8",
  "rand_core 0.6.4",
  "sec1",
@@ -4719,6 +4759,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
+name = "flagset"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4735,6 +4781,21 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "fork-tree"
@@ -4899,7 +4960,30 @@ dependencies = [
  "sp-runtime",
  "sp-state-machine",
  "spinners",
- "substrate-rpc-client",
+ "substrate-rpc-client 0.58.0",
+ "tokio",
+]
+
+[[package]]
+name = "frame-remote-externalities"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "452d68a9b7dd6044ae6d2ea9c0993f026f894e352e230231de464f9cc6838376"
+dependencies = [
+ "futures",
+ "indicatif",
+ "jsonrpsee",
+ "log",
+ "parity-scale-codec",
+ "rand 0.8.5",
+ "serde",
+ "sp-core",
+ "sp-crypto-hashing",
+ "sp-io",
+ "sp-runtime",
+ "sp-state-machine",
+ "spinners",
+ "substrate-rpc-client 0.59.0",
  "tokio",
 ]
 
@@ -5277,6 +5361,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -5508,6 +5593,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
+name = "hickory-net"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "084e7bd6a377435d568f652153e571b50970d7ccc1d1eeec0519f834632287e1"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "hickory-proto 0.26.2",
+ "idna",
+ "ipnet",
+ "jni 0.22.4",
+ "rand 0.10.2",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "hickory-proto"
 version = "0.24.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5558,6 +5667,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "hickory-proto"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e2da0694c15b44c6f68a6b05e0233617008c54080e31d6eb848d858a9c5b38d"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni 0.22.4",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.2",
+ "ring 0.17.14",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "hickory-resolver"
 version = "0.24.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5594,6 +5723,32 @@ dependencies = [
  "rand 0.9.2",
  "resolv-conf",
  "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e4f9f4603319422d482738f3f6fe5aac03157fdbfed1cd85a3ff45adb09072f"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-net",
+ "hickory-proto 0.26.2",
+ "ipconfig",
+ "ipnet",
+ "jni 0.22.4",
+ "moka",
+ "ndk-context",
+ "once_cell",
+ "parking_lot 0.12.5",
+ "rand 0.10.2",
+ "resolv-conf",
+ "smallvec",
+ "system-configuration",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6738,6 +6893,22 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "is"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d08f9118d003d441f79c1070e84d0a2a89f35721ca8ae0cd5e1f9026dc4a2517"
+dependencies = [
+ "crc",
+ "serde",
+ "str0m-proto",
+ "subtle 2.6.1",
+ "tracing",
+]
 
 [[package]]
 name = "itertools"
@@ -6847,7 +7018,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.0",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -6855,10 +7026,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version 0.4.1",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "jobserver"
@@ -7030,6 +7250,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8f198d1db720e4940b5a493201d199d9f24f568f8f746bd13706243a2f71598"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.1",
+]
+
+[[package]]
 name = "keccak-asm"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7070,7 +7300,7 @@ dependencies = [
  "pallet-remote-proxy",
  "parity-scale-codec",
  "polkadot-primitives",
- "polkadot-runtime-common",
+ "polkadot-runtime-common 29.0.0",
  "scale-info",
  "smallvec",
  "sp-core",
@@ -7719,6 +7949,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "litep2p"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b43bcd3f698c589f30fb44db886f48c1b5d96c6a6f8ee5c41cdb21d24da2869"
+dependencies = [
+ "async-trait",
+ "bs58",
+ "bytes",
+ "cid",
+ "ed25519-dalek",
+ "enum-display",
+ "futures",
+ "futures-timer",
+ "hickory-resolver 0.26.2",
+ "indexmap 2.13.0",
+ "ip_network",
+ "libc",
+ "mockall",
+ "multiaddr",
+ "multibase",
+ "multihash",
+ "multihash-codetable",
+ "network-interface",
+ "parking_lot 0.12.5",
+ "pin-project",
+ "prost 0.13.5",
+ "prost-build 0.14.3",
+ "quinn-udp 0.6.2",
+ "rand 0.8.5",
+ "ring 0.17.14",
+ "serde",
+ "sha2 0.11.0",
+ "simple-dns",
+ "smallvec",
+ "snow",
+ "socket2 0.5.10",
+ "str0m",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-tungstenite",
+ "tokio-util",
+ "tracing",
+ "uint 0.10.0",
+ "unsigned-varint 0.8.0",
+ "url",
+ "x25519-dalek",
+ "x509-parser 0.17.0",
+ "yamux 0.13.10",
+ "yasna",
+ "zeroize",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7945,7 +8229,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
 dependencies = [
  "byteorder",
- "keccak",
+ "keccak 0.1.6",
  "rand_core 0.6.4",
  "zeroize",
 ]
@@ -8090,9 +8374,11 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60384411b100398c5b2fdca476eed82e9898d09f2c60d1b1b66c5080ebe06118"
 dependencies = [
+ "blake2b_simd",
  "digest 0.11.3",
  "multihash-derive",
  "sha2 0.11.0",
+ "sha3 0.11.0",
 ]
 
 [[package]]
@@ -8152,6 +8438,12 @@ dependencies = [
  "simba",
  "typenum",
 ]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "netlink-packet-core"
@@ -8239,6 +8531,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -8463,10 +8764,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-src"
+version = "300.6.1+3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "openssl-src",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"
@@ -8513,7 +8861,7 @@ dependencies = [
  "log",
  "pallet-assets",
  "pallet-balances",
- "pallet-staking-async",
+ "pallet-staking-async 0.14.0",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
@@ -9208,6 +9556,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-election-provider-multi-phase"
+version = "50.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ead0797f6940859fb83414aadce37a33d73a25d66a776991015ef46ccfb91296"
+dependencies = [
+ "frame-benchmarking",
+ "frame-election-provider-support",
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "rand 0.8.5",
+ "scale-info",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-crypto-hashing",
+ "sp-io",
+ "sp-npos-elections",
+ "sp-runtime",
+ "strum 0.26.3",
+]
+
+[[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "48.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9460,7 +9831,7 @@ dependencies = [
  "pallet-bags-list",
  "pallet-delegated-staking",
  "pallet-nomination-pools",
- "pallet-staking-async",
+ "pallet-staking-async 0.14.0",
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
@@ -9633,15 +10004,70 @@ dependencies = [
  "pallet-session",
  "pallet-society",
  "pallet-staking",
- "pallet-staking-async",
+ "pallet-staking-async 0.14.0",
  "pallet-staking-async-ah-client",
- "pallet-state-trie-migration",
+ "pallet-state-trie-migration 55.0.0",
  "pallet-treasury",
  "pallet-vesting",
  "pallet-xcm",
  "parity-scale-codec",
  "polkadot-parachain-primitives",
- "polkadot-runtime-common",
+ "polkadot-runtime-common 29.0.0",
+ "polkadot-runtime-parachains",
+ "scale-info",
+ "serde",
+ "sp-api",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-staking",
+ "sp-std",
+ "staging-xcm",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
+]
+
+[[package]]
+name = "pallet-rc-migrator"
+version = "0.1.0"
+source = "git+https://github.com/polkadot-fellows/runtimes?tag=v2.5.0#3936c7e4d42b449b964e41bd7b69d5f1db1e3a1f"
+dependencies = [
+ "frame-benchmarking",
+ "frame-election-provider-support",
+ "frame-support",
+ "frame-system",
+ "hex-literal",
+ "impl-trait-for-tuples",
+ "log",
+ "pallet-asset-rate",
+ "pallet-bags-list",
+ "pallet-balances",
+ "pallet-bounties",
+ "pallet-child-bounties",
+ "pallet-conviction-voting",
+ "pallet-delegated-staking",
+ "pallet-fast-unstake",
+ "pallet-indices",
+ "pallet-message-queue",
+ "pallet-multisig",
+ "pallet-nomination-pools",
+ "pallet-preimage",
+ "pallet-proxy",
+ "pallet-recovery",
+ "pallet-referenda",
+ "pallet-scheduler",
+ "pallet-session",
+ "pallet-society",
+ "pallet-staking",
+ "pallet-staking-async 0.15.0",
+ "pallet-staking-async-ah-client",
+ "pallet-state-trie-migration 56.0.0",
+ "pallet-treasury",
+ "pallet-vesting",
+ "pallet-xcm",
+ "parity-scale-codec",
+ "polkadot-parachain-primitives",
+ "polkadot-runtime-common 30.0.0",
  "polkadot-runtime-parachains",
  "scale-info",
  "serde",
@@ -9959,6 +10385,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-staking-async"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56acc1c494eec3715c95119d1845fd5f98e28ade0472e5205e26d05b15339fda"
+dependencies = [
+ "frame-benchmarking",
+ "frame-election-provider-support",
+ "frame-support",
+ "frame-system",
+ "log",
+ "pallet-staking-async-rc-client",
+ "parity-scale-codec",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "scale-info",
+ "serde",
+ "sp-application-crypto",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-crypto-hashing",
+ "sp-io",
+ "sp-npos-elections",
+ "sp-runtime",
+ "sp-staking",
+]
+
+[[package]]
 name = "pallet-staking-async-ah-client"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10038,6 +10491,23 @@ name = "pallet-state-trie-migration"
 version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae995c6d8e8d87763f0157e37fe15525777dccd51f93daedeb9b4dc154fc10f2"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+]
+
+[[package]]
+name = "pallet-state-trie-migration"
+version = "56.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e38d40f440bfa994108d7e4506a3d785eaf0fbc57b3d2308c5a5b258d7328f0a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10352,7 +10822,7 @@ dependencies = [
  "parachains-common-types",
  "parity-scale-codec",
  "polkadot-primitives",
- "polkadot-runtime-common",
+ "polkadot-runtime-common 29.0.0",
  "scale-info",
  "sp-consensus-aura",
  "sp-core",
@@ -10551,7 +11021,7 @@ dependencies = [
  "frame-election-provider-support",
  "frame-executive",
  "frame-metadata-hash-extension",
- "frame-remote-externalities",
+ "frame-remote-externalities 0.61.0",
  "frame-support",
  "frame-system",
  "frame-system-benchmarking",
@@ -10572,7 +11042,7 @@ dependencies = [
  "pallet-child-bounties",
  "pallet-conviction-voting",
  "pallet-delegated-staking",
- "pallet-election-provider-multi-phase",
+ "pallet-election-provider-multi-phase 50.0.0",
  "pallet-election-provider-support-benchmarking",
  "pallet-fast-unstake",
  "pallet-grandpa",
@@ -10581,14 +11051,13 @@ dependencies = [
  "pallet-mmr",
  "pallet-multisig",
  "pallet-nomination-pools",
- "pallet-nomination-pools-benchmarking",
  "pallet-nomination-pools-runtime-api",
  "pallet-offences",
  "pallet-offences-benchmarking",
  "pallet-parameters",
  "pallet-preimage",
  "pallet-proxy",
- "pallet-rc-migrator",
+ "pallet-rc-migrator 0.1.0 (git+https://github.com/polkadot-fellows/runtimes?tag=v2.5.0)",
  "pallet-referenda",
  "pallet-scheduler",
  "pallet-session",
@@ -10599,7 +11068,6 @@ dependencies = [
  "pallet-staking-reward-curve",
  "pallet-staking-reward-fn",
  "pallet-staking-runtime-api",
- "pallet-state-trie-migration",
  "pallet-sudo",
  "pallet-timestamp",
  "pallet-transaction-payment",
@@ -10614,9 +11082,8 @@ dependencies = [
  "paseo-runtime-constants",
  "polkadot-parachain-primitives",
  "polkadot-primitives",
- "polkadot-runtime-common",
+ "polkadot-runtime-common 30.0.0",
  "polkadot-runtime-parachains",
- "relay-common",
  "scale-info",
  "separator",
  "serde_json",
@@ -10661,7 +11128,7 @@ dependencies = [
  "pallet-remote-proxy",
  "parity-scale-codec",
  "polkadot-primitives",
- "polkadot-runtime-common",
+ "polkadot-runtime-common 29.0.0",
  "scale-info",
  "smallvec",
  "sp-core",
@@ -10792,7 +11259,7 @@ dependencies = [
  "parity-scale-codec",
  "polkadot-parachain-primitives",
  "polkadot-primitives",
- "polkadot-runtime-common",
+ "polkadot-runtime-common 29.0.0",
  "primitive-types 0.13.1",
  "scale-info",
  "serde_json",
@@ -10855,7 +11322,7 @@ dependencies = [
  "paseo-runtime-constants",
  "paseo-system-emulated-network",
  "people-paseo-runtime",
- "polkadot-runtime-common",
+ "polkadot-runtime-common 29.0.0",
  "sp-io",
  "sp-runtime",
  "staging-xcm",
@@ -10882,7 +11349,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-executive",
  "frame-metadata-hash-extension",
- "frame-remote-externalities",
+ "frame-remote-externalities 0.60.0",
  "frame-support",
  "frame-system",
  "frame-system-benchmarking",
@@ -10940,7 +11407,7 @@ dependencies = [
  "parity-scale-codec",
  "paseo-runtime-constants",
  "polkadot-parachain-primitives",
- "polkadot-runtime-common",
+ "polkadot-runtime-common 29.0.0",
  "scale-info",
  "serde",
  "serde_json",
@@ -11200,7 +11667,58 @@ dependencies = [
  "pallet-babe",
  "pallet-balances",
  "pallet-broker",
- "pallet-election-provider-multi-phase",
+ "pallet-election-provider-multi-phase 49.0.0",
+ "pallet-fast-unstake",
+ "pallet-identity",
+ "pallet-session",
+ "pallet-staking",
+ "pallet-staking-reward-fn",
+ "pallet-timestamp",
+ "pallet-transaction-payment",
+ "pallet-treasury",
+ "pallet-vesting",
+ "parity-scale-codec",
+ "polkadot-primitives",
+ "polkadot-runtime-parachains",
+ "rustc-hex",
+ "scale-info",
+ "serde",
+ "slot-range-helper",
+ "sp-api",
+ "sp-core",
+ "sp-inherents",
+ "sp-io",
+ "sp-keyring",
+ "sp-npos-elections",
+ "sp-runtime",
+ "sp-session",
+ "sp-staking",
+ "staging-xcm",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
+ "static_assertions",
+]
+
+[[package]]
+name = "polkadot-runtime-common"
+version = "30.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de8a88a482826087a008c33ac09a445121080ee8ae663f4df1c534959ccb311f"
+dependencies = [
+ "bitvec",
+ "frame-benchmarking",
+ "frame-election-provider-support",
+ "frame-support",
+ "frame-system",
+ "impl-trait-for-tuples",
+ "libsecp256k1",
+ "log",
+ "pallet-asset-rate",
+ "pallet-authorship",
+ "pallet-babe",
+ "pallet-balances",
+ "pallet-broker",
+ "pallet-election-provider-multi-phase 50.0.0",
  "pallet-fast-unstake",
  "pallet-identity",
  "pallet-session",
@@ -11241,7 +11759,7 @@ dependencies = [
  "pallet-remote-proxy",
  "parity-scale-codec",
  "polkadot-primitives",
- "polkadot-runtime-common",
+ "polkadot-runtime-common 29.0.0",
  "scale-info",
  "smallvec",
  "sp-core",
@@ -11600,6 +12118,17 @@ checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
 dependencies = [
  "predicates-core",
  "termtree",
+]
+
+[[package]]
+name = "prefix-trie"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
 ]
 
 [[package]]
@@ -11966,7 +12495,7 @@ dependencies = [
  "futures-io",
  "pin-project-lite",
  "quinn-proto",
- "quinn-udp",
+ "quinn-udp 0.5.14",
  "rustc-hash 2.1.1",
  "rustls",
  "socket2 0.6.2",
@@ -12009,6 +12538,19 @@ dependencies = [
  "socket2 0.6.2",
  "tracing",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ca72c3f2792761ab5fa848490694cbc728c7f659669ed4320c4c79c12150966"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "socket2 0.6.2",
+ "tracing",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12062,6 +12604,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20 0.10.2",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12099,6 +12652,12 @@ dependencies = [
  "getrandom 0.3.4",
  "serde",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_distr"
@@ -12569,7 +13128,7 @@ checksum = "1a4fc4b1a7b5e67fc3e741da59b3c61b54a18e6b1df8163119c14d7ab92a2e29"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
- "polkadot-runtime-common",
+ "polkadot-runtime-common 29.0.0",
  "smallvec",
  "sp-core",
  "sp-runtime",
@@ -12690,7 +13249,7 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -12751,7 +13310,7 @@ checksum = "19787cda76408ec5404443dc8b31795c87cd8fec49762dc75fa727740d34acc1"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
- "jni",
+ "jni 0.21.1",
  "log",
  "once_cell",
  "rustls",
@@ -12888,7 +13447,34 @@ dependencies = [
  "sc-chain-spec-derive",
  "sc-client-api",
  "sc-executor",
- "sc-network",
+ "sc-network 0.58.0",
+ "sc-telemetry",
+ "serde",
+ "serde_json",
+ "sp-blockchain",
+ "sp-core",
+ "sp-crypto-hashing",
+ "sp-genesis-builder",
+ "sp-io",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-tracing",
+]
+
+[[package]]
+name = "sc-chain-spec"
+version = "52.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3646b60a61b73ab43beb4f1b6f277559ab3c172df27ad735f471551f1fd40a1"
+dependencies = [
+ "array-bytes 6.2.3",
+ "docify",
+ "memmap2 0.9.10",
+ "parity-scale-codec",
+ "sc-chain-spec-derive",
+ "sc-client-api",
+ "sc-executor",
+ "sc-network 0.59.0",
  "sc-telemetry",
  "serde",
  "serde_json",
@@ -12981,7 +13567,7 @@ dependencies = [
  "mockall",
  "parking_lot 0.12.5",
  "sc-client-api",
- "sc-network-types",
+ "sc-network-types 0.22.0",
  "sc-utils",
  "serde",
  "sp-blockchain",
@@ -13012,15 +13598,15 @@ dependencies = [
  "parking_lot 0.12.5",
  "rand 0.8.5",
  "sc-block-builder",
- "sc-chain-spec",
+ "sc-chain-spec 51.0.0",
  "sc-client-api",
  "sc-client-db",
  "sc-consensus",
- "sc-network",
+ "sc-network 0.58.0",
  "sc-network-common",
  "sc-network-gossip",
  "sc-network-sync",
- "sc-network-types",
+ "sc-network-types 0.22.0",
  "sc-telemetry",
  "sc-transaction-pool-api",
  "sc-utils",
@@ -13124,8 +13710,37 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.5",
  "sc-client-api",
- "sc-network",
- "sc-network-types",
+ "sc-network 0.58.0",
+ "sc-network-types 0.22.0",
+ "sc-transaction-pool-api",
+ "sp-api",
+ "sp-consensus",
+ "sp-core",
+ "sp-keystore",
+ "sp-mixnet",
+ "sp-runtime",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "sc-mixnet"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6dec39bcbc9b983e78113c091df9033f9d13e58a0aa22f86b7c1c753b593282"
+dependencies = [
+ "array-bytes 6.2.3",
+ "arrayvec",
+ "blake2 0.10.6",
+ "bytes",
+ "futures",
+ "futures-timer",
+ "log",
+ "mixnet",
+ "parity-scale-codec",
+ "parking_lot 0.12.5",
+ "sc-client-api",
+ "sc-network 0.59.0",
+ "sc-network-types 0.23.0",
  "sc-transaction-pool-api",
  "sp-api",
  "sp-consensus",
@@ -13155,7 +13770,7 @@ dependencies = [
  "ip_network",
  "libp2p",
  "linked_hash_set",
- "litep2p",
+ "litep2p 0.14.3",
  "log",
  "mockall",
  "parity-scale-codec",
@@ -13167,7 +13782,7 @@ dependencies = [
  "rand 0.8.5",
  "sc-client-api",
  "sc-network-common",
- "sc-network-types",
+ "sc-network-types 0.22.0",
  "sc-utils",
  "schnellru",
  "serde",
@@ -13185,6 +13800,62 @@ dependencies = [
  "unsigned-varint 0.7.2",
  "void",
  "wasm-timer",
+ "zeroize",
+]
+
+[[package]]
+name = "sc-network"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9707727b8183a153c1f7e4a92d14b603a87ad4f0cac573281f28246822e26ae"
+dependencies = [
+ "array-bytes 6.2.3",
+ "async-channel",
+ "async-trait",
+ "asynchronous-codec 0.6.2",
+ "bytes",
+ "cid",
+ "either",
+ "fnv",
+ "futures",
+ "futures-timer",
+ "hmac 0.12.1",
+ "ip_network",
+ "libp2p",
+ "linked_hash_set",
+ "litep2p 0.15.2",
+ "log",
+ "mockall",
+ "p256",
+ "parity-scale-codec",
+ "parking_lot 0.12.5",
+ "partial_sort",
+ "pin-project",
+ "prost 0.12.6",
+ "prost-build 0.13.5",
+ "rand 0.8.5",
+ "sc-client-api",
+ "sc-network-common",
+ "sc-network-types 0.23.0",
+ "sc-utils",
+ "schnellru",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "smallvec",
+ "sp-arithmetic",
+ "sp-blockchain",
+ "sp-core",
+ "sp-crypto-hashing",
+ "sp-runtime",
+ "substrate-prometheus-endpoint",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+ "unsigned-varint 0.7.2",
+ "void",
+ "wasm-timer",
+ "x509-cert",
  "zeroize",
 ]
 
@@ -13209,10 +13880,10 @@ dependencies = [
  "futures",
  "futures-timer",
  "log",
- "sc-network",
+ "sc-network 0.58.0",
  "sc-network-common",
  "sc-network-sync",
- "sc-network-types",
+ "sc-network-types 0.22.0",
  "schnellru",
  "sp-runtime",
  "substrate-prometheus-endpoint",
@@ -13237,9 +13908,9 @@ dependencies = [
  "prost-build 0.13.5",
  "sc-client-api",
  "sc-consensus",
- "sc-network",
+ "sc-network 0.58.0",
  "sc-network-common",
- "sc-network-types",
+ "sc-network-types 0.22.0",
  "sc-utils",
  "schnellru",
  "smallvec",
@@ -13265,7 +13936,29 @@ dependencies = [
  "ed25519-dalek",
  "libp2p-identity",
  "libp2p-kad",
- "litep2p",
+ "litep2p 0.14.3",
+ "log",
+ "multiaddr",
+ "multihash",
+ "rand 0.8.5",
+ "serde",
+ "serde_with",
+ "thiserror 1.0.69",
+ "zeroize",
+]
+
+[[package]]
+name = "sc-network-types"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3512ad5829a6567cfce05690a1ef5b68daf7e947818c92a3a7c8dfd14362ea3"
+dependencies = [
+ "bs58",
+ "bytes",
+ "ed25519-dalek",
+ "libp2p-identity",
+ "libp2p-kad",
+ "litep2p 0.15.2",
  "log",
  "multiaddr",
  "multihash",
@@ -13284,8 +13977,30 @@ checksum = "61055d19abe495142874ace184c7971cd2c14bc9d2f46481a4b494ceccf93c89"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
- "sc-chain-spec",
- "sc-mixnet",
+ "sc-chain-spec 51.0.0",
+ "sc-mixnet 0.28.0",
+ "sc-transaction-pool-api",
+ "scale-info",
+ "serde",
+ "serde_json",
+ "sp-core",
+ "sp-rpc",
+ "sp-runtime",
+ "sp-statement-store",
+ "sp-version",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "sc-rpc-api"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6d4a401f851d5607bb846947d7a689c2c059b23d3895c17a9617434e3a30d8f"
+dependencies = [
+ "jsonrpsee",
+ "parity-scale-codec",
+ "sc-chain-spec 52.0.0",
+ "sc-mixnet 0.29.0",
  "sc-transaction-pool-api",
  "scale-info",
  "serde",
@@ -13567,6 +14282,21 @@ dependencies = [
  "pbkdf2",
  "salsa20",
  "sha2 0.10.9",
+]
+
+[[package]]
+name = "sctp-proto"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a22cbe1d867f74fc377b9e63ac74457ea7dcfda23a0deaba6af083ad7e060019"
+dependencies = [
+ "bytes",
+ "crc",
+ "log",
+ "rand 0.9.2",
+ "rustc-hash 2.1.1",
+ "slab",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -13914,7 +14644,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
  "digest 0.10.7",
- "keccak",
+ "keccak 0.1.6",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+dependencies = [
+ "digest 0.11.3",
+ "keccak 0.2.2",
 ]
 
 [[package]]
@@ -13964,6 +14704,22 @@ dependencies = [
  "paste",
  "wide",
 ]
+
+[[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version 0.4.1",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "simple-dns"
@@ -14890,7 +15646,7 @@ dependencies = [
  "byteorder",
  "digest 0.10.7",
  "sha2 0.10.9",
- "sha3",
+ "sha3 0.10.8",
  "twox-hash",
 ]
 
@@ -15599,6 +16355,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "str0m"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8522aa06c731cfdc1488e32de7fcebcfc8d9d86d49a6ecc95a64779fe7b545f2"
+dependencies = [
+ "arrayvec",
+ "base64ct",
+ "combine",
+ "dimpl",
+ "fastrand",
+ "is",
+ "sctp-proto",
+ "serde",
+ "str0m-openssl",
+ "str0m-proto",
+ "subtle 2.6.1",
+ "time",
+ "tracing",
+]
+
+[[package]]
+name = "str0m-openssl"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae33ce33dcd4dd2d9b6c01e7e425b604be9b811f69511b4387e76d5a36fe606b"
+dependencies = [
+ "libc",
+ "openssl",
+ "openssl-sys",
+ "str0m-proto",
+ "tracing",
+]
+
+[[package]]
+name = "str0m-proto"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8f3d99f2cf6c76a502e45feb896ea71e54787ede8744bcdb215acfbfcb905dd"
+dependencies = [
+ "base64ct",
+ "dimpl",
+ "fastrand",
+ "openssl",
+ "serde",
+ "subtle 2.6.1",
+ "time",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15698,7 +16503,21 @@ dependencies = [
  "async-trait",
  "jsonrpsee",
  "log",
- "sc-rpc-api",
+ "sc-rpc-api 0.58.0",
+ "serde",
+ "sp-runtime",
+]
+
+[[package]]
+name = "substrate-rpc-client"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c0713adacabf1583780b98f7cf3b46d453b6766c9939ef9214b8473f06c6234"
+dependencies = [
+ "async-trait",
+ "jsonrpsee",
+ "log",
+ "sc-rpc-api 0.59.0",
  "serde",
  "sp-runtime",
 ]
@@ -16143,6 +16962,27 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tls_codec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b"
+dependencies = [
+ "tls_codec_derive",
+ "zeroize",
+]
+
+[[package]]
+name = "tls_codec_derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "tokio"
@@ -16624,6 +17464,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "verifiable"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16672,7 +17518,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "sha2 0.10.9",
- "sha3",
+ "sha3 0.10.8",
  "zeroize",
 ]
 
@@ -17246,7 +18092,7 @@ checksum = "b2ada5471729528a13576e9504bad28db078852dddf48f8f9a170a1b53e6bdf7"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
- "polkadot-runtime-common",
+ "polkadot-runtime-common 29.0.0",
  "smallvec",
  "sp-core",
  "sp-dap",
@@ -17884,6 +18730,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "x509-cert"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
+dependencies = [
+ "const-oid 0.9.6",
+ "der",
+ "spki",
+ "tls_codec",
+]
+
+[[package]]
 name = "x509-parser"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -17893,7 +18751,7 @@ dependencies = [
  "data-encoding",
  "der-parser 9.0.0",
  "lazy_static",
- "nom",
+ "nom 7.1.3",
  "oid-registry 0.7.1",
  "rusticata-macros",
  "thiserror 1.0.69",
@@ -17910,7 +18768,7 @@ dependencies = [
  "data-encoding",
  "der-parser 10.0.0",
  "lazy_static",
- "nom",
+ "nom 7.1.3",
  "oid-registry 0.8.1",
  "rusticata-macros",
  "thiserror 2.0.18",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1326,12 +1326,12 @@ name = "asset-hub-paseo-emulated-chain"
 version = "2.3.1"
 dependencies = [
  "asset-hub-paseo-runtime",
- "assets-common",
+ "assets-common 0.35.0",
  "cumulus-primitives-core",
  "emulated-integration-tests-common",
  "frame-support",
  "integration-tests-helpers",
- "parachains-common",
+ "parachains-common 34.0.0",
  "paseo-emulated-chain",
  "penpal-emulated-chain",
  "polkadot-parachain-primitives",
@@ -1348,7 +1348,7 @@ version = "2.3.1"
 dependencies = [
  "approx",
  "asset-test-utils",
- "assets-common",
+ "assets-common 0.35.0",
  "bp-asset-hub-kusama",
  "bp-asset-hub-paseo",
  "bp-bridge-hub-kusama",
@@ -1363,13 +1363,13 @@ dependencies = [
  "cumulus-pallet-xcmp-queue",
  "cumulus-primitives-aura",
  "cumulus-primitives-core",
- "cumulus-primitives-utility",
+ "cumulus-primitives-utility 0.31.0",
  "ethereum-standards",
  "frame-benchmarking",
  "frame-election-provider-support",
  "frame-executive",
  "frame-metadata-hash-extension",
- "frame-remote-externalities 0.60.0",
+ "frame-remote-externalities 0.61.0",
  "frame-support",
  "frame-system",
  "frame-system-benchmarking",
@@ -1422,7 +1422,7 @@ dependencies = [
  "pallet-pgas-allowance",
  "pallet-preimage",
  "pallet-proxy",
- "pallet-rc-migrator 0.1.0 (git+https://github.com/polkadot-fellows/runtimes?tag=v2.4.0)",
+ "pallet-rc-migrator",
  "pallet-referenda",
  "pallet-revive",
  "pallet-scheduler",
@@ -1446,7 +1446,7 @@ dependencies = [
  "pallet-xcm-benchmarks",
  "pallet-xcm-bridge-hub-router",
  "pallet-xcm-precompiles",
- "parachains-common",
+ "parachains-common 34.0.0",
  "parachains-runtimes-test-utils",
  "parity-scale-codec",
  "paseo-runtime",
@@ -1454,7 +1454,7 @@ dependencies = [
  "polkadot-core-primitives",
  "polkadot-parachain-primitives",
  "polkadot-primitives",
- "polkadot-runtime-common 29.0.0",
+ "polkadot-runtime-common 30.0.0",
  "primitive-types 0.13.1",
  "scale-info",
  "serde_json",
@@ -1499,11 +1499,11 @@ dependencies = [
 
 [[package]]
 name = "asset-test-utils"
-version = "35.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bf9ad45989b197789cf78a13395f27480c643c974320a34acfec5eb774cbc6a"
+checksum = "294244afbc4c0668ff1d1a5b2980d313d062934b2ef8e15e2ea0bb216397d2fd"
 dependencies = [
- "assets-common",
+ "assets-common 0.35.0",
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcmp-queue",
  "cumulus-primitives-core",
@@ -1517,7 +1517,7 @@ dependencies = [
  "pallet-timestamp",
  "pallet-xcm",
  "pallet-xcm-bridge-hub-router",
- "parachains-common",
+ "parachains-common 34.0.0",
  "parachains-runtimes-test-utils",
  "parity-scale-codec",
  "sp-io",
@@ -1545,7 +1545,36 @@ dependencies = [
  "pallet-revive",
  "pallet-revive-uapi",
  "pallet-xcm",
- "parachains-common",
+ "parachains-common 32.1.0",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-api",
+ "sp-core",
+ "sp-runtime",
+ "staging-xcm",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
+ "tracing",
+]
+
+[[package]]
+name = "assets-common"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd54eef4dcb0934600db3f9ab178a18b07187374d2bfaf8743b1b458444eec88"
+dependencies = [
+ "cumulus-primitives-core",
+ "ethereum-standards",
+ "frame-support",
+ "frame-system",
+ "impl-trait-for-tuples",
+ "pallet-asset-conversion",
+ "pallet-assets",
+ "pallet-revive",
+ "pallet-revive-uapi",
+ "pallet-xcm",
+ "parachains-common 34.0.0",
  "parity-scale-codec",
  "scale-info",
  "serde",
@@ -1985,7 +2014,7 @@ dependencies = [
  "bp-runtime",
  "frame-support",
  "frame-system",
- "parachains-common",
+ "parachains-common 32.1.0",
  "polkadot-primitives",
  "sp-api",
  "sp-std",
@@ -2248,7 +2277,7 @@ dependencies = [
  "bridge-hub-paseo-runtime",
  "emulated-integration-tests-common",
  "frame-support",
- "parachains-common",
+ "parachains-common 34.0.0",
  "sp-core",
  "sp-keyring",
  "staging-xcm",
@@ -2258,7 +2287,7 @@ dependencies = [
 name = "bridge-hub-paseo-runtime"
 version = "2.3.1"
 dependencies = [
- "assets-common",
+ "assets-common 0.35.0",
  "bp-asset-hub-kusama",
  "bp-asset-hub-paseo",
  "bp-bridge-hub-kusama",
@@ -2283,7 +2312,7 @@ dependencies = [
  "cumulus-pallet-xcmp-queue",
  "cumulus-primitives-aura",
  "cumulus-primitives-core",
- "cumulus-primitives-utility",
+ "cumulus-primitives-utility 0.31.0",
  "frame-benchmarking",
  "frame-executive",
  "frame-metadata-hash-extension",
@@ -2315,13 +2344,13 @@ dependencies = [
  "pallet-xcm",
  "pallet-xcm-benchmarks",
  "pallet-xcm-bridge-hub",
- "parachains-common",
+ "parachains-common 34.0.0",
  "parachains-runtimes-test-utils",
  "parity-scale-codec",
  "paseo-runtime-constants",
  "polkadot-core-primitives",
  "polkadot-parachain-primitives",
- "polkadot-runtime-common 29.0.0",
+ "polkadot-runtime-common 30.0.0",
  "scale-info",
  "serde",
  "serde_json",
@@ -2373,9 +2402,9 @@ dependencies = [
 
 [[package]]
 name = "bridge-hub-test-utils"
-version = "0.34.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da16ddd93c70b1a70cb77a6c4c193c1ead1e3b4c51d2ff122af7b6741086f6d2"
+checksum = "bdae556937d58ef50e7bfc73a29d2391742358ae682414a803639be075f11d6f"
 dependencies = [
  "asset-test-utils",
  "bp-header-chain",
@@ -2399,7 +2428,7 @@ dependencies = [
  "pallet-utility",
  "pallet-xcm",
  "pallet-xcm-bridge-hub",
- "parachains-common",
+ "parachains-common 34.0.0",
  "parachains-runtimes-test-utils",
  "parity-scale-codec",
  "sp-core",
@@ -2491,7 +2520,7 @@ dependencies = [
  "cumulus-pallet-xcmp-queue",
  "cumulus-primitives-aura",
  "cumulus-primitives-core",
- "cumulus-primitives-utility",
+ "cumulus-primitives-utility 0.31.0",
  "frame-benchmarking",
  "frame-executive",
  "frame-metadata-hash-extension",
@@ -2520,12 +2549,12 @@ dependencies = [
  "pallet-utility",
  "pallet-xcm",
  "pallet-xcm-benchmarks",
- "parachains-common",
+ "parachains-common 34.0.0",
  "parachains-runtimes-test-utils",
  "parity-scale-codec",
  "paseo-runtime-constants",
  "polkadot-parachain-primitives",
- "polkadot-runtime-common 29.0.0",
+ "polkadot-runtime-common 30.0.0",
  "scale-info",
  "serde",
  "serde_json",
@@ -2852,7 +2881,7 @@ dependencies = [
  "cumulus-primitives-core",
  "emulated-integration-tests-common",
  "frame-support",
- "parachains-common",
+ "parachains-common 34.0.0",
  "sp-core",
 ]
 
@@ -2870,7 +2899,7 @@ dependencies = [
  "cumulus-pallet-xcmp-queue",
  "cumulus-primitives-aura",
  "cumulus-primitives-core",
- "cumulus-primitives-utility",
+ "cumulus-primitives-utility 0.31.0",
  "frame-benchmarking",
  "frame-executive",
  "frame-metadata-hash-extension",
@@ -2906,13 +2935,13 @@ dependencies = [
  "pallet-utility",
  "pallet-xcm",
  "pallet-xcm-benchmarks",
- "parachains-common",
+ "parachains-common 34.0.0",
  "parachains-runtimes-test-utils",
  "parity-scale-codec",
  "paseo-runtime-constants",
  "polkadot-core-primitives",
  "polkadot-parachain-primitives",
- "polkadot-runtime-common 29.0.0",
+ "polkadot-runtime-common 30.0.0",
  "scale-info",
  "serde_json",
  "sp-api",
@@ -3129,7 +3158,7 @@ dependencies = [
  "cumulus-primitives-core",
  "emulated-integration-tests-common",
  "frame-support",
- "parachains-common",
+ "parachains-common 34.0.0",
  "sp-core",
 ]
 
@@ -3147,12 +3176,12 @@ dependencies = [
  "pallet-broker",
  "pallet-message-queue",
  "pallet-xcm",
- "parachains-common",
+ "parachains-common 34.0.0",
  "parity-scale-codec",
  "paseo-runtime",
  "paseo-runtime-constants",
  "paseo-system-emulated-network",
- "polkadot-runtime-common 29.0.0",
+ "polkadot-runtime-common 30.0.0",
  "polkadot-runtime-parachains",
  "sp-runtime",
  "staging-xcm",
@@ -3172,7 +3201,7 @@ dependencies = [
  "cumulus-pallet-xcmp-queue",
  "cumulus-primitives-aura",
  "cumulus-primitives-core",
- "cumulus-primitives-utility",
+ "cumulus-primitives-utility 0.31.0",
  "frame-benchmarking",
  "frame-executive",
  "frame-metadata-hash-extension",
@@ -3199,13 +3228,13 @@ dependencies = [
  "pallet-utility",
  "pallet-xcm",
  "pallet-xcm-benchmarks",
- "parachains-common",
+ "parachains-common 34.0.0",
  "parachains-runtimes-test-utils",
  "parity-scale-codec",
  "paseo-runtime-constants",
  "polkadot-core-primitives",
  "polkadot-parachain-primitives",
- "polkadot-runtime-common 29.0.0",
+ "polkadot-runtime-common 30.0.0",
  "scale-info",
  "serde",
  "serde_json",
@@ -3668,9 +3697,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "748eed29a70f2dc60b77d805d6ef43e44d0038418822f5328fe2ed623d5e5783"
+checksum = "4a51374b1ee59727af2d00836bacc1937cc46b49a9471240823d1edff88b80ae"
 dependencies = [
  "approx",
  "bitflags 1.3.2",
@@ -3682,7 +3711,7 @@ dependencies = [
  "frame-system",
  "pallet-message-queue",
  "parity-scale-codec",
- "polkadot-runtime-common 29.0.0",
+ "polkadot-runtime-common 30.0.0",
  "polkadot-runtime-parachains",
  "scale-info",
  "sp-core",
@@ -3778,6 +3807,24 @@ dependencies = [
  "pallet-asset-conversion",
  "parity-scale-codec",
  "polkadot-runtime-common 29.0.0",
+ "sp-runtime",
+ "staging-xcm",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
+]
+
+[[package]]
+name = "cumulus-primitives-utility"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8661627fd4c2ff1bfca57da46537a1e93b6fcb770979c3e49d1c0714c50c857e"
+dependencies = [
+ "cumulus-primitives-core",
+ "frame-support",
+ "log",
+ "pallet-asset-conversion",
+ "parity-scale-codec",
+ "polkadot-runtime-common 30.0.0",
  "sp-runtime",
  "staging-xcm",
  "staging-xcm-builder",
@@ -4420,9 +4467,9 @@ checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "emulated-integration-tests-common"
-version = "34.0.0"
+version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f17c7e9c06c1de048295391667a0b9c48af8e8ee1b1b280fbb27359bd214924"
+checksum = "815dd162891f0ea60bd98738d9ac2c02ab8e341d905b5197049f3bb7f65d796b"
 dependencies = [
  "asset-test-utils",
  "bp-messages",
@@ -4443,13 +4490,13 @@ dependencies = [
  "pallet-whitelist",
  "pallet-xcm",
  "pallet-xcm-bridge-hub",
- "parachains-common",
+ "parachains-common 34.0.0",
  "parity-scale-codec",
  "paste",
  "polkadot-parachain-primitives",
  "polkadot-primitives",
  "polkadot-runtime-parachains",
- "sc-consensus-grandpa",
+ "sc-consensus-grandpa 0.44.0",
  "sp-authority-discovery",
  "sp-consensus-babe",
  "sp-consensus-beefy",
@@ -9975,61 +10022,6 @@ dependencies = [
 [[package]]
 name = "pallet-rc-migrator"
 version = "0.1.0"
-source = "git+https://github.com/polkadot-fellows/runtimes?tag=v2.4.0#b3f18b26b80a2255dab06f78f70416358df64d61"
-dependencies = [
- "frame-benchmarking",
- "frame-election-provider-support",
- "frame-support",
- "frame-system",
- "hex-literal",
- "impl-trait-for-tuples",
- "log",
- "pallet-asset-rate",
- "pallet-bags-list",
- "pallet-balances",
- "pallet-bounties",
- "pallet-child-bounties",
- "pallet-conviction-voting",
- "pallet-delegated-staking",
- "pallet-fast-unstake",
- "pallet-indices",
- "pallet-message-queue",
- "pallet-multisig",
- "pallet-nomination-pools",
- "pallet-preimage",
- "pallet-proxy",
- "pallet-recovery",
- "pallet-referenda",
- "pallet-scheduler",
- "pallet-session",
- "pallet-society",
- "pallet-staking",
- "pallet-staking-async 0.14.0",
- "pallet-staking-async-ah-client",
- "pallet-state-trie-migration 55.0.0",
- "pallet-treasury",
- "pallet-vesting",
- "pallet-xcm",
- "parity-scale-codec",
- "polkadot-parachain-primitives",
- "polkadot-runtime-common 29.0.0",
- "polkadot-runtime-parachains",
- "scale-info",
- "serde",
- "sp-api",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-staking",
- "sp-std",
- "staging-xcm",
- "staging-xcm-builder",
- "staging-xcm-executor",
-]
-
-[[package]]
-name = "pallet-rc-migrator"
-version = "0.1.0"
 source = "git+https://github.com/polkadot-fellows/runtimes?tag=v2.5.0#3936c7e4d42b449b964e41bd7b69d5f1db1e3a1f"
 dependencies = [
  "frame-benchmarking",
@@ -10808,7 +10800,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e8405ed90568235a8425f64cbd1e82e98be8750acc39a59d28217d445fd059"
 dependencies = [
  "cumulus-primitives-core",
- "cumulus-primitives-utility",
+ "cumulus-primitives-utility 0.30.0",
  "frame-support",
  "frame-system",
  "pallet-assets",
@@ -10835,6 +10827,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "parachains-common"
+version = "34.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "364585773f72e4310758e0ba93f294260646aa91ac57822f8b03beb978e56e84"
+dependencies = [
+ "cumulus-primitives-core",
+ "cumulus-primitives-utility 0.31.0",
+ "frame-support",
+ "frame-system",
+ "pallet-assets",
+ "pallet-authorship",
+ "pallet-balances",
+ "pallet-collator-selection",
+ "pallet-message-queue",
+ "pallet-multi-asset-bounties",
+ "pallet-treasury",
+ "pallet-xcm",
+ "parachains-common-types",
+ "parity-scale-codec",
+ "polkadot-primitives",
+ "polkadot-runtime-common 30.0.0",
+ "scale-info",
+ "sp-consensus-aura",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "staging-parachain-info",
+ "staging-xcm",
+ "staging-xcm-executor",
+ "tracing",
+]
+
+[[package]]
 name = "parachains-common-types"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10847,9 +10872,9 @@ dependencies = [
 
 [[package]]
 name = "parachains-runtimes-test-utils"
-version = "33.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3606b08f046ea6b8d890d2bb48e937cab4f913a7e68315f8013d23fbd6df128"
+checksum = "6f514702e0d6bb79d875156bf3c612f2574cb8a0faf08f5277cad11ff91c9ad4"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcmp-queue",
@@ -10863,7 +10888,7 @@ dependencies = [
  "pallet-session",
  "pallet-timestamp",
  "pallet-xcm",
- "parachains-common",
+ "parachains-common 34.0.0",
  "parity-scale-codec",
  "polkadot-parachain-primitives",
  "sp-consensus-aura",
@@ -10999,11 +11024,11 @@ version = "2.3.1"
 dependencies = [
  "emulated-integration-tests-common",
  "pallet-staking",
- "parachains-common",
+ "parachains-common 34.0.0",
  "paseo-runtime",
  "paseo-runtime-constants",
  "polkadot-primitives",
- "sc-consensus-grandpa",
+ "sc-consensus-grandpa 0.43.1",
  "sp-authority-discovery",
  "sp-consensus-babe",
  "sp-consensus-beefy",
@@ -11057,7 +11082,7 @@ dependencies = [
  "pallet-parameters",
  "pallet-preimage",
  "pallet-proxy",
- "pallet-rc-migrator 0.1.0 (git+https://github.com/polkadot-fellows/runtimes?tag=v2.5.0)",
+ "pallet-rc-migrator",
  "pallet-referenda",
  "pallet-scheduler",
  "pallet-session",
@@ -11128,7 +11153,7 @@ dependencies = [
  "pallet-remote-proxy",
  "parity-scale-codec",
  "polkadot-primitives",
- "polkadot-runtime-common 29.0.0",
+ "polkadot-runtime-common 30.0.0",
  "scale-info",
  "smallvec",
  "sp-core",
@@ -11207,7 +11232,7 @@ dependencies = [
  "cumulus-primitives-core",
  "emulated-integration-tests-common",
  "frame-support",
- "parachains-common",
+ "parachains-common 34.0.0",
  "paseo-emulated-chain",
  "penpal-runtime",
  "sp-core",
@@ -11217,11 +11242,11 @@ dependencies = [
 
 [[package]]
 name = "penpal-runtime"
-version = "0.41.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13abbb02bb0962f7ff2df93b23cd121ad35dfc27b93d337f3bcc2b8068157a9d"
+checksum = "dd47e60349bb854ff30839e2e868aa40a0a9e8261adb1bd1c4f57cc1108b0b77"
 dependencies = [
- "assets-common",
+ "assets-common 0.35.0",
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-session-benchmarking",
@@ -11229,7 +11254,7 @@ dependencies = [
  "cumulus-pallet-xcmp-queue",
  "cumulus-primitives-aura",
  "cumulus-primitives-core",
- "cumulus-primitives-utility",
+ "cumulus-primitives-utility 0.31.0",
  "frame-benchmarking",
  "frame-executive",
  "frame-metadata-hash-extension",
@@ -11255,11 +11280,11 @@ dependencies = [
  "pallet-transaction-payment-rpc-runtime-api",
  "pallet-utility",
  "pallet-xcm",
- "parachains-common",
+ "parachains-common 34.0.0",
  "parity-scale-codec",
  "polkadot-parachain-primitives",
  "polkadot-primitives",
- "polkadot-runtime-common 29.0.0",
+ "polkadot-runtime-common 30.0.0",
  "primitive-types 0.13.1",
  "scale-info",
  "serde_json",
@@ -11294,7 +11319,7 @@ dependencies = [
  "cumulus-primitives-core",
  "emulated-integration-tests-common",
  "frame-support",
- "parachains-common",
+ "parachains-common 34.0.0",
  "paseo-emulated-chain",
  "paseo-runtime-constants",
  "people-paseo-runtime",
@@ -11316,13 +11341,13 @@ dependencies = [
  "pallet-identity",
  "pallet-message-queue",
  "pallet-xcm",
- "parachains-common",
+ "parachains-common 34.0.0",
  "parity-scale-codec",
  "paseo-runtime",
  "paseo-runtime-constants",
  "paseo-system-emulated-network",
  "people-paseo-runtime",
- "polkadot-runtime-common 29.0.0",
+ "polkadot-runtime-common 30.0.0",
  "sp-io",
  "sp-runtime",
  "staging-xcm",
@@ -11334,7 +11359,7 @@ dependencies = [
 name = "people-paseo-runtime"
 version = "2.3.1"
 dependencies = [
- "assets-common",
+ "assets-common 0.35.0",
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-session-benchmarking",
@@ -11343,7 +11368,7 @@ dependencies = [
  "cumulus-pallet-xcmp-queue",
  "cumulus-primitives-aura",
  "cumulus-primitives-core",
- "cumulus-primitives-utility",
+ "cumulus-primitives-utility 0.31.0",
  "ed25519-zebra",
  "enumflags2",
  "frame-benchmarking",
@@ -11402,12 +11427,12 @@ dependencies = [
  "pallet-verify-signature",
  "pallet-xcm",
  "pallet-xcm-benchmarks",
- "parachains-common",
+ "parachains-common 34.0.0",
  "parachains-runtimes-test-utils",
  "parity-scale-codec",
  "paseo-runtime-constants",
  "polkadot-parachain-primitives",
- "polkadot-runtime-common 29.0.0",
+ "polkadot-runtime-common 30.0.0",
  "scale-info",
  "serde",
  "serde_json",
@@ -13122,13 +13147,13 @@ dependencies = [
 
 [[package]]
 name = "rococo-runtime-constants"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a4fc4b1a7b5e67fc3e741da59b3c61b54a18e6b1df8163119c14d7ab92a2e29"
+checksum = "ba3280620038f62c2f864bc74862ffcc7120ee1e80769a71069d25ea8bf3d018"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
- "polkadot-runtime-common 29.0.0",
+ "polkadot-runtime-common 30.0.0",
  "smallvec",
  "sp-core",
  "sp-runtime",
@@ -13580,6 +13605,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "sc-consensus"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e2fb20ddb804347b3586ac72dc54eeb12a70d93b5604a114f1140042342205"
+dependencies = [
+ "async-trait",
+ "futures",
+ "log",
+ "mockall",
+ "parking_lot 0.12.5",
+ "sc-client-api",
+ "sc-network-types 0.23.0",
+ "sc-utils",
+ "serde",
+ "sp-blockchain",
+ "sp-consensus",
+ "sp-core",
+ "sp-runtime",
+ "sp-state-machine",
+ "substrate-prometheus-endpoint",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "sc-consensus-grandpa"
 version = "0.43.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13601,12 +13650,58 @@ dependencies = [
  "sc-chain-spec 51.0.0",
  "sc-client-api",
  "sc-client-db",
- "sc-consensus",
+ "sc-consensus 0.57.0",
  "sc-network 0.58.0",
  "sc-network-common",
- "sc-network-gossip",
- "sc-network-sync",
+ "sc-network-gossip 0.58.0",
+ "sc-network-sync 0.57.0",
  "sc-network-types 0.22.0",
+ "sc-telemetry",
+ "sc-transaction-pool-api",
+ "sc-utils",
+ "serde_json",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-arithmetic",
+ "sp-blockchain",
+ "sp-consensus",
+ "sp-consensus-grandpa",
+ "sp-core",
+ "sp-crypto-hashing",
+ "sp-keystore",
+ "sp-runtime",
+ "substrate-prometheus-endpoint",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "sc-consensus-grandpa"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0e0bbba47a60ac734c99ba9d9d9c6cfdbb7bb0aee04261b1ceb75b8d4d66471"
+dependencies = [
+ "ahash",
+ "array-bytes 6.2.3",
+ "async-trait",
+ "dyn-clone",
+ "finality-grandpa",
+ "fork-tree",
+ "futures",
+ "futures-timer",
+ "log",
+ "parity-scale-codec",
+ "parking_lot 0.12.5",
+ "rand 0.8.5",
+ "sc-block-builder",
+ "sc-chain-spec 52.0.0",
+ "sc-client-api",
+ "sc-client-db",
+ "sc-consensus 0.58.0",
+ "sc-network 0.59.0",
+ "sc-network-common",
+ "sc-network-gossip 0.59.0",
+ "sc-network-sync 0.58.0",
+ "sc-network-types 0.23.0",
  "sc-telemetry",
  "sc-transaction-pool-api",
  "sc-utils",
@@ -13882,8 +13977,28 @@ dependencies = [
  "log",
  "sc-network 0.58.0",
  "sc-network-common",
- "sc-network-sync",
+ "sc-network-sync 0.57.0",
  "sc-network-types 0.22.0",
+ "schnellru",
+ "sp-runtime",
+ "substrate-prometheus-endpoint",
+ "tracing",
+]
+
+[[package]]
+name = "sc-network-gossip"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7735544c82711fa583599627647b93f033656ac7b7b2750b7b6f90446298d49"
+dependencies = [
+ "ahash",
+ "futures",
+ "futures-timer",
+ "log",
+ "sc-network 0.59.0",
+ "sc-network-common",
+ "sc-network-sync 0.58.0",
+ "sc-network-types 0.23.0",
  "schnellru",
  "sp-runtime",
  "substrate-prometheus-endpoint",
@@ -13907,10 +14022,45 @@ dependencies = [
  "prost 0.12.6",
  "prost-build 0.13.5",
  "sc-client-api",
- "sc-consensus",
+ "sc-consensus 0.57.0",
  "sc-network 0.58.0",
  "sc-network-common",
  "sc-network-types 0.22.0",
+ "sc-utils",
+ "schnellru",
+ "smallvec",
+ "sp-arithmetic",
+ "sp-blockchain",
+ "sp-consensus",
+ "sp-core",
+ "sp-runtime",
+ "substrate-prometheus-endpoint",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "sc-network-sync"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a06c876e3f50e2e8a6a842fd01b99401dcc5dec2e673af761814c8618c2d32"
+dependencies = [
+ "array-bytes 6.2.3",
+ "async-channel",
+ "async-trait",
+ "fork-tree",
+ "futures",
+ "log",
+ "mockall",
+ "parity-scale-codec",
+ "prost 0.12.6",
+ "prost-build 0.13.5",
+ "sc-client-api",
+ "sc-consensus 0.58.0",
+ "sc-network 0.59.0",
+ "sc-network-common",
+ "sc-network-types 0.23.0",
  "sc-utils",
  "schnellru",
  "smallvec",
@@ -14868,7 +15018,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b526a021c00d0003786e1d491a2959bd64112c1884ef3133235e68138c132a2"
 dependencies = [
  "alloy-core",
- "assets-common",
+ "assets-common 0.33.0",
  "frame-support",
  "frame-system",
  "hex-literal",
@@ -15237,9 +15387,9 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-runtime-test-common"
-version = "0.27.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a3623610558968badd26346e8cc16620e5ed691340da04b2cc8d7db2b73f641"
+checksum = "1000a549a4caed0c85629af941efc91e57cd5c1756b2f38053032cfd1f7a8991"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -16751,7 +16901,7 @@ dependencies = [
  "frame-support",
  "kusama-runtime-constants",
  "pallet-revive",
- "parachains-common",
+ "parachains-common 32.1.0",
  "polkadot-core-primitives",
  "polkadot-primitives",
  "polkadot-runtime-constants",
@@ -16768,7 +16918,7 @@ dependencies = [
  "array-bytes 9.3.0",
  "frame-support",
  "pallet-revive",
- "parachains-common",
+ "parachains-common 34.0.0",
  "paseo-runtime-constants",
  "polkadot-core-primitives",
  "polkadot-primitives",
@@ -16826,9 +16976,9 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "testnet-parachains-constants"
-version = "23.0.0"
+version = "24.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a5ece069ce4278c9f328170904d01363f1715dd3f4ae2a7df380acda311370c"
+checksum = "a32a1fdc27a6874177a60b2c3dccd1fb7f938faee3106ddecbf37cb656b3b74a"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -18086,13 +18236,13 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "westend-runtime-constants"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ada5471729528a13576e9504bad28db078852dddf48f8f9a170a1b53e6bdf7"
+checksum = "9bd2ee96db546fee57f061748ec4ff4d3c8cce9d70cd4b3f70e13b0cb094493b"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
- "polkadot-runtime-common 29.0.0",
+ "polkadot-runtime-common 30.0.0",
  "smallvec",
  "sp-core",
  "sp-dap",
@@ -18777,9 +18927,9 @@ dependencies = [
 
 [[package]]
 name = "xcm-emulator"
-version = "0.31.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64d4a0e44dfa6a964ea037b05765bdc8e0adc1db49ceb7395e50b0a440850359"
+checksum = "fb418ce25fa0e5fffebcf8910379078efdba12f6f97c298faf0b3fa3d5fc1921"
 dependencies = [
  "array-bytes 6.2.3",
  "cumulus-pallet-parachain-system",
@@ -18793,7 +18943,7 @@ dependencies = [
  "pallet-balances",
  "pallet-message-queue",
  "pallet-timestamp",
- "parachains-common",
+ "parachains-common 34.0.0",
  "parity-scale-codec",
  "paste",
  "polkadot-parachain-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ indiv-pallet-resources = { path = "pallets/resources", default-features = false 
 indiv-pallet-score = { path = "pallets/score", default-features = false }
 indiv-pallet-storage-initialization = { path = "pallets/storage-initialization", default-features = false }
 indiv-pallet-value-transfer-auth = { path = "pallets/value-transfer-auth", default-features = false }
-pallet-rc-migrator = { git = "https://github.com/polkadot-fellows/runtimes", tag = "v2.4.0", default-features = false }
+pallet-rc-migrator = { git = "https://github.com/polkadot-fellows/runtimes", tag = "v2.5.0", default-features = false }
 pallet-ah-ops = { git = "https://github.com/polkadot-fellows/runtimes", tag = "v2.4.0", default-features = false }
 pallet-election-provider-multi-block = { version = "0.11.0", default-features = false }
 pallet-staking-async = { version = "0.14.0", default-features = false }
@@ -159,8 +159,8 @@ paseo-emulated-chain = { path = "integration-tests/emulated/chains/relays/paseo"
 assert_matches = { version = "1.5.0" }
 approx = { version = "0.5.1" }
 array-bytes = { version = "9.3.0" }
-asset-test-utils = { version = "35.0.0" }
-assets-common = { version = "0.33.0", default-features = false }
+asset-test-utils = { version = "37.0.0" }
+assets-common = { version = "0.35.0", default-features = false }
 authority-discovery-primitives = { version = "43.0.0", default-features = false, package = "sp-authority-discovery" }
 babe-primitives = { version = "0.49.0", default-features = false, package = "sp-consensus-babe" }
 beefy-primitives = { version = "31.0.0", default-features = false, package = "sp-consensus-beefy" }
@@ -175,7 +175,7 @@ bp-runtime = { version = "0.28.0", default-features = false }
 bp-xcm-bridge-hub = { version = "0.14.0", default-features = false }
 bp-xcm-bridge-hub-router = { version = "0.25.0", default-features = false }
 bridge-hub-common = { version = "0.22.0", default-features = false }
-bridge-hub-test-utils = { version = "0.34.0" }
+bridge-hub-test-utils = { version = "0.36.0" }
 bridge-runtime-common = { version = "0.30.0", default-features = false }
 clap = { version = "4.5.0" }
 codec = { package = "parity-scale-codec", version = "3.7.5", default-features = false }
@@ -186,11 +186,11 @@ cumulus-pallet-parachain-system = { version = "0.29.0", default-features = false
 cumulus-pallet-weight-reclaim = { version = "0.11.0", default-features = false }
 cumulus-pallet-session-benchmarking = { version = "30.0.0", default-features = false }
 cumulus-pallet-xcm = { version = "0.27.0", default-features = false }
-cumulus-pallet-xcmp-queue = { version = "0.30.0", default-features = false }
+cumulus-pallet-xcmp-queue = { version = "0.31.0", default-features = false }
 cumulus-primitives-aura = { version = "0.24.0", default-features = false }
 cumulus-primitives-core = { version = "0.26.0", default-features = false }
-cumulus-primitives-utility = { version = "0.30.0", default-features = false }
-emulated-integration-tests-common = { version = "34.0.0" }
+cumulus-primitives-utility = { version = "0.31.0", default-features = false }
+emulated-integration-tests-common = { version = "36.0.0" }
 enumflags2 = { version = "0.7.7" }
 frame-benchmarking = { version = "49.0.0", default-features = false }
 frame-election-provider-support = { version = "48.0.0", default-features = false }
@@ -235,7 +235,7 @@ pallet-collective = { version = "49.0.0", default-features = false }
 pallet-conviction-voting = { version = "49.0.0", default-features = false }
 pallet-dap = { version = "0.6.0", default-features = false }
 pallet-core-fellowship = { version = "33.0.0", default-features = false }
-pallet-election-provider-multi-phase = { version = "49.0.0", default-features = false }
+pallet-election-provider-multi-phase = { version = "50.0.0", default-features = false }
 pallet-election-provider-support-benchmarking = { version = "48.0.0", default-features = false }
 pallet-fast-unstake = { version = "48.0.0", default-features = false }
 pallet-glutton = { version = "35.0.0", default-features = false }
@@ -296,10 +296,10 @@ pallet-xcm-precompiles = { version = "0.9.0", default-features = false }
 pallet-xcm-bridge-hub = { version = "0.25.0", default-features = false }
 pallet-xcm-bridge-hub-router = { version = "0.27.0", default-features = false }
 parachain-info = { version = "0.28.0", default-features = false, package = "staging-parachain-info" }
-parachains-common = { version = "32.0.0", default-features = false }
-parachains-runtimes-test-utils = { version = "33.0.0" }
+parachains-common = { version = "34.0.0", default-features = false }
+parachains-runtimes-test-utils = { version = "35.0.0" }
 paste = { version = "1.0.14" }
-penpal-runtime = { version = "0.41.0" }
+penpal-runtime = { version = "0.43.0" }
 people-kusama-emulated-chain = { path = "integration-tests/emulated/chains/parachains/people/people-kusama" }
 people-kusama-runtime = { path = "system-parachains/people/people-kusama" }
 paseo-core-primitives = { version = "21.0.0", default-features = false }
@@ -308,10 +308,10 @@ paseo-primitives = { version = "25.0.0", package = "polkadot-primitives", defaul
 polkadot-core-primitives = { version = "24.0.0", default-features = false }
 polkadot-parachain-primitives = { version = "23.0.0", default-features = false }
 polkadot-primitives = { version = "25.0.0", default-features = false }
-polkadot-runtime-common = { version = "29.0.0", default-features = false }
+polkadot-runtime-common = { version = "30.0.0", default-features = false }
 primitive-types = { version = "0.13.1", default-features = false }
 frame-metadata-hash-extension = { version = "0.16.0", default-features = false }
-remote-externalities = { version = "0.60.0", package = "frame-remote-externalities" }
+remote-externalities = { version = "0.61.0", package = "frame-remote-externalities" }
 runtime-parachains = { version = "28.0.0", default-features = false, package = "polkadot-runtime-parachains" }
 sc-chain-spec = { version = "51.0.0" }
 sc-network = { version = "0.58.0" }
@@ -351,7 +351,7 @@ snowbridge-pallet-system-v2 = { version = "0.12.0", default-features = false }
 snowbridge-pallet-system-frontend = { version = "0.11.0", default-features = false }
 snowbridge-inbound-queue-primitives = { version = "0.14.0", default-features = false }
 snowbridge-runtime-common = { version = "0.23.0", default-features = false }
-snowbridge-runtime-test-common = { version = "0.27.0" }
+snowbridge-runtime-test-common = { version = "0.29.0" }
 snowbridge-system-runtime-api = { version = "0.22.0", default-features = false }
 snowbridge-system-v2-runtime-api = { version = "0.11.0", default-features = false }
 sp-api = { version = "43.0.0", default-features = false }
@@ -387,7 +387,7 @@ system-parachains-common = { git = "https://github.com/polkadot-fellows/runtimes
 tokio = { version = "1.45.0" }
 xcm = { version = "24.0.0", default-features = false, package = "staging-xcm" }
 xcm-builder = { version = "29.0.0", default-features = false, package = "staging-xcm-builder" }
-xcm-emulator = { version = "0.31.0" }
+xcm-emulator = { version = "0.33.0" }
 xcm-executor = { version = "28.0.0", default-features = false, package = "staging-xcm-executor" }
 xcm-runtime-apis = { version = "0.16.0", default-features = false }
 anyhow = { version = "1.0.82" }

--- a/relay/paseo/Cargo.toml
+++ b/relay/paseo/Cargo.toml
@@ -9,8 +9,11 @@ license.workspace = true
 
 [dependencies]
 
+# Fellowship v2.5.0 dependency overrides are scoped to the relay; system chains retain
+# the workspace versions. Other SDK dependencies already resolve to the required versions.
+
 # Asset Hub Migration concerning deps
-pallet-rc-migrator = { workspace = true }
+pallet-rc-migrator = { git = "https://github.com/polkadot-fellows/runtimes", tag = "v2.5.0", default-features = false }
 # End: Asset Hub Migration concerning deps
 
 codec = { features = ["derive", "max-encoded-len"], workspace = true }
@@ -56,7 +59,7 @@ pallet-staking-async-rc-client = { workspace = true, features = ["xcm-sender"] }
 pallet-transaction-payment = { workspace = true }
 pallet-transaction-payment-rpc-runtime-api = { workspace = true }
 pallet-conviction-voting = { workspace = true }
-pallet-election-provider-multi-phase = { workspace = true }
+pallet-election-provider-multi-phase = { version = "50.0.0", default-features = false }
 pallet-fast-unstake = { workspace = true }
 frame-executive = { workspace = true }
 frame-metadata-hash-extension = { workspace = true }
@@ -80,7 +83,6 @@ pallet-staking = { workspace = true }
 pallet-staking-reward-fn = { workspace = true }
 pallet-staking-reward-curve = { workspace = true }
 pallet-staking-runtime-api = { workspace = true }
-pallet-state-trie-migration = { workspace = true }
 frame-system = { workspace = true }
 frame-system-rpc-runtime-api = { workspace = true }
 paseo-runtime-constants = { workspace = true }
@@ -99,13 +101,11 @@ frame-system-benchmarking = { optional = true, workspace = true }
 pallet-election-provider-support-benchmarking = { optional = true, workspace = true }
 pallet-offences-benchmarking = { optional = true, workspace = true }
 pallet-session-benchmarking = { optional = true, workspace = true }
-pallet-nomination-pools-benchmarking = { optional = true, workspace = true }
 hex-literal = { workspace = true }
 
-polkadot-runtime-common = { workspace = true }
+polkadot-runtime-common = { version = "30.0.0", default-features = false }
 runtime-parachains = { workspace = true }
 polkadot-primitives = { workspace = true }
-relay-common = { workspace = true }
 
 xcm = { workspace = true }
 xcm-executor = { workspace = true }
@@ -122,7 +122,7 @@ approx = { workspace = true }
 sp-keyring = { workspace = true }
 sp-trie = { workspace = true }
 separator = { workspace = true }
-remote-externalities = { workspace = true }
+remote-externalities = { version = "0.61.0", package = "frame-remote-externalities" }
 tokio = { features = ["macros"], workspace = true }
 sp-tracing = { workspace = true }
 hex-literal = { workspace = true }
@@ -177,7 +177,6 @@ std = [
 	"pallet-message-queue/std",
 	"pallet-mmr/std",
 	"pallet-multisig/std",
-	"pallet-nomination-pools-benchmarking?/std",
 	"pallet-nomination-pools-runtime-api/std",
 	"pallet-nomination-pools/std",
 	"pallet-offences-benchmarking?/std",
@@ -194,7 +193,6 @@ std = [
 	"pallet-staking-reward-fn/std",
 	"pallet-staking-runtime-api/std",
 	"pallet-staking/std",
-	"pallet-state-trie-migration/std",
 	"pallet-sudo/std",
 	"pallet-timestamp/std",
 	"pallet-transaction-payment-rpc-runtime-api/std",
@@ -209,7 +207,6 @@ std = [
 	"polkadot-parachain-primitives/std",
 	"polkadot-primitives/std",
 	"polkadot-runtime-common/std",
-	"relay-common/std",
 	"runtime-parachains/std",
 	"scale-info/std",
 	"serde_json/std",
@@ -264,7 +261,6 @@ runtime-benchmarks = [
 	"pallet-message-queue/runtime-benchmarks",
 	"pallet-mmr/runtime-benchmarks",
 	"pallet-multisig/runtime-benchmarks",
-	"pallet-nomination-pools-benchmarking/runtime-benchmarks",
 	"pallet-nomination-pools/runtime-benchmarks",
 	"pallet-offences-benchmarking/runtime-benchmarks",
 	"pallet-offences/runtime-benchmarks",
@@ -278,7 +274,6 @@ runtime-benchmarks = [
 	"pallet-staking-async-ah-client/runtime-benchmarks",
 	"pallet-staking-async-rc-client/runtime-benchmarks",
 	"pallet-staking/runtime-benchmarks",
-	"pallet-state-trie-migration/runtime-benchmarks",
 	"pallet-sudo/runtime-benchmarks",
 	"pallet-timestamp/runtime-benchmarks",
 	"pallet-transaction-payment/runtime-benchmarks",
@@ -292,7 +287,6 @@ runtime-benchmarks = [
 	"polkadot-parachain-primitives/runtime-benchmarks",
 	"polkadot-primitives/runtime-benchmarks",
 	"polkadot-runtime-common/runtime-benchmarks",
-	"relay-common/runtime-benchmarks",
 	"runtime-parachains/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
 	"sp-staking/runtime-benchmarks",
@@ -341,7 +335,6 @@ try-runtime = [
 	"pallet-staking-async-ah-client/try-runtime",
 	"pallet-staking-async-rc-client/try-runtime",
 	"pallet-staking/try-runtime",
-	"pallet-state-trie-migration/try-runtime",
 	"pallet-sudo/try-runtime",
 	"pallet-timestamp/try-runtime",
 	"pallet-transaction-payment/try-runtime",

--- a/relay/paseo/Cargo.toml
+++ b/relay/paseo/Cargo.toml
@@ -9,11 +9,8 @@ license.workspace = true
 
 [dependencies]
 
-# Fellowship v2.5.0 dependency overrides are scoped to the relay; system chains retain
-# the workspace versions. Other SDK dependencies already resolve to the required versions.
-
 # Asset Hub Migration concerning deps
-pallet-rc-migrator = { git = "https://github.com/polkadot-fellows/runtimes", tag = "v2.5.0", default-features = false }
+pallet-rc-migrator = { workspace = true }
 # End: Asset Hub Migration concerning deps
 
 codec = { features = ["derive", "max-encoded-len"], workspace = true }
@@ -59,7 +56,7 @@ pallet-staking-async-rc-client = { workspace = true, features = ["xcm-sender"] }
 pallet-transaction-payment = { workspace = true }
 pallet-transaction-payment-rpc-runtime-api = { workspace = true }
 pallet-conviction-voting = { workspace = true }
-pallet-election-provider-multi-phase = { version = "50.0.0", default-features = false }
+pallet-election-provider-multi-phase = { workspace = true }
 pallet-fast-unstake = { workspace = true }
 frame-executive = { workspace = true }
 frame-metadata-hash-extension = { workspace = true }
@@ -103,7 +100,7 @@ pallet-offences-benchmarking = { optional = true, workspace = true }
 pallet-session-benchmarking = { optional = true, workspace = true }
 hex-literal = { workspace = true }
 
-polkadot-runtime-common = { version = "30.0.0", default-features = false }
+polkadot-runtime-common = { workspace = true }
 runtime-parachains = { workspace = true }
 polkadot-primitives = { workspace = true }
 
@@ -122,7 +119,7 @@ approx = { workspace = true }
 sp-keyring = { workspace = true }
 sp-trie = { workspace = true }
 separator = { workspace = true }
-remote-externalities = { version = "0.61.0", package = "frame-remote-externalities" }
+remote-externalities = { workspace = true }
 tokio = { features = ["macros"], workspace = true }
 sp-tracing = { workspace = true }
 hex-literal = { workspace = true }

--- a/relay/paseo/src/genesis_config_presets.rs
+++ b/relay/paseo/src/genesis_config_presets.rs
@@ -135,7 +135,7 @@ fn testnet_accounts() -> Vec<AccountId> {
 }
 
 fn default_parachains_host_configuration() -> HostConfiguration<polkadot_primitives::BlockNumber> {
-	use polkadot_primitives::{MAX_CODE_SIZE, MAX_POV_SIZE};
+	use polkadot_primitives::MAX_POV_SIZE;
 
 	let executor_parameteres = ExecutorParams::from(
 		&[
@@ -149,7 +149,9 @@ fn default_parachains_host_configuration() -> HostConfiguration<polkadot_primiti
 		validation_upgrade_cooldown: 2u32,
 		validation_upgrade_delay: 2,
 		code_retention_period: 1200,
-		max_code_size: MAX_CODE_SIZE,
+		// Keep below the 5 MiB block length so code-upgrade benchmarks aren't filtered as
+		// oversized. TODO: https://github.com/paritytech/polkadot-sdk/issues/12969
+		max_code_size: 3 * 1024 * 1024,
 		max_pov_size: MAX_POV_SIZE,
 		max_head_data_size: 32 * 1024,
 		max_upward_queue_count: 174172,

--- a/relay/paseo/src/genesis_config_presets.rs
+++ b/relay/paseo/src/genesis_config_presets.rs
@@ -135,7 +135,7 @@ fn testnet_accounts() -> Vec<AccountId> {
 }
 
 fn default_parachains_host_configuration() -> HostConfiguration<polkadot_primitives::BlockNumber> {
-	use polkadot_primitives::MAX_POV_SIZE;
+	use polkadot_primitives::{MAX_CODE_SIZE, MAX_POV_SIZE};
 
 	let executor_parameteres = ExecutorParams::from(
 		&[
@@ -149,9 +149,7 @@ fn default_parachains_host_configuration() -> HostConfiguration<polkadot_primiti
 		validation_upgrade_cooldown: 2u32,
 		validation_upgrade_delay: 2,
 		code_retention_period: 1200,
-		// Keep below the 5 MiB block length so code-upgrade benchmarks aren't filtered as
-		// oversized. TODO: https://github.com/paritytech/polkadot-sdk/issues/12969
-		max_code_size: 3 * 1024 * 1024,
+		max_code_size: MAX_CODE_SIZE,
 		max_pov_size: MAX_POV_SIZE,
 		max_head_data_size: 32 * 1024,
 		max_upward_queue_count: 174172,

--- a/relay/paseo/src/lib.rs
+++ b/relay/paseo/src/lib.rs
@@ -3576,7 +3576,7 @@ mod remote_tests {
 	use std::env::var;
 
 	async fn remote_ext_test_setup() -> RemoteExternalities<Block> {
-		let transport: String = var("WS").unwrap_or("wss://paseo-rpc.dwellir.com".to_string());
+		let transport: String = var("WS").unwrap_or("wss://paseo-rpc.n.dwellir.com".to_string());
 		let maybe_state_snapshot: Option<SnapshotConfig> = var("SNAP").map(|s| s.into()).ok();
 		Builder::<Block>::default()
 			.mode(if let Some(state_snapshot) = maybe_state_snapshot {
@@ -3949,6 +3949,19 @@ mod post_ahm_filter_tests {
 mod upgrade_tests {
 	use super::*;
 	use frame_support::traits::OnRuntimeUpgrade;
+
+	#[test]
+	fn block_length_preserves_class_limits_and_caps_header_size() {
+		let current = <Runtime as frame_system::Config>::BlockLength::get();
+		let previous = BlockLength::get();
+		for class in [DispatchClass::Normal, DispatchClass::Operational, DispatchClass::Mandatory] {
+			assert_eq!(current.max.get(class), previous.max.get(class));
+		}
+		assert_eq!(*current.max.get(DispatchClass::Normal), 3_932_160);
+		assert_eq!(*current.max.get(DispatchClass::Operational), 5 * 1024 * 1024);
+		assert_eq!(*current.max.get(DispatchClass::Mandatory), 5 * 1024 * 1024);
+		assert_eq!(current.max_header_size(), 100 * 1024);
+	}
 
 	#[test]
 	fn retired_trie_migration_storage_is_removed_without_touching_other_pallets() {

--- a/relay/paseo/src/lib.rs
+++ b/relay/paseo/src/lib.rs
@@ -166,7 +166,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: alloc::borrow::Cow::Borrowed("paseo"),
 	impl_name: alloc::borrow::Cow::Borrowed("paseo-testnet"),
 	authoring_version: 0,
-	spec_version: 2_003_001,
+	spec_version: 2_005_000,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 26,
@@ -213,8 +213,14 @@ impl Contains<RuntimeCall> for PostAhmFilter {
 			FastUnstake(..) |
 			Slots(..) |
 			Auctions(..) |
-			StateTrieMigration(..) |
 			AssetRate(..) => false,
+
+			// Session keys are managed via Asset Hub post-AHM (forwarded to the relay through
+			// `ah_client::set_keys_from_ah`); the direct relay extrinsics are disabled.
+			Session(
+				pallet_session::Call::<Runtime>::set_keys { .. } |
+				pallet_session::Call::<Runtime>::purge_keys { .. },
+			) => false,
 
 			// Crowdloan: only dissolve, refund, and withdraw are allowed.
 			Crowdloan(
@@ -232,10 +238,24 @@ impl Contains<RuntimeCall> for PostAhmFilter {
 	}
 }
 
+parameter_types! {
+	/// Maximum length of block. Up to 5 MiB.
+	///
+	/// `max_header_size` caps the pre-runtime digest and header overhead checked at block
+	/// initialization.
+	pub RuntimeBlockLength: limits::BlockLength = limits::BlockLength::builder()
+		.max_length(5 * 1024 * 1024)
+		.modify_max_length_for_class(DispatchClass::Normal, |m| {
+			*m = NORMAL_DISPATCH_RATIO * *m
+		})
+		.max_header_size(100 * 1024)
+		.build();
+}
+
 impl frame_system::Config for Runtime {
 	type BaseCallFilter = PostAhmFilter;
 	type BlockWeights = BlockWeights;
-	type BlockLength = BlockLength;
+	type BlockLength = RuntimeBlockLength;
 	type RuntimeOrigin = RuntimeOrigin;
 	type RuntimeCall = RuntimeCall;
 	type Nonce = Nonce;
@@ -524,11 +544,6 @@ impl_opaque_keys! {
 	}
 }
 
-parameter_types! {
-	// all keys are 32 bytes, except beefy being 33
-	pub KeyDeposit: Balance = deposit(1, 5 * 32 + 33);
-}
-
 impl pallet_session::Config for Runtime {
 	type Currency = Balances;
 	type RuntimeEvent = RuntimeEvent;
@@ -541,7 +556,8 @@ impl pallet_session::Config for Runtime {
 	type Keys = SessionKeys;
 	type WeightInfo = weights::pallet_session::WeightInfo<Runtime>;
 	type DisablingStrategy = pallet_session::disabling::UpToLimitWithReEnablingDisablingStrategy;
-	// TODO: we will set this post-AHM
+	// `set_keys`/`purge_keys` are disabled on the relay post-AHM via `PostAhmFilter`; session keys
+	// are now managed on Asset Hub, so no deposit is taken here.
 	type KeyDeposit = ();
 }
 
@@ -1795,27 +1811,6 @@ impl ah_client::SendToAssetHub for StakingXcmToAssetHub {
 	}
 }
 
-parameter_types! {
-	// The deposit configuration for the singed migration. Specially if you want to allow any signed account to do the migration (see `SignedFilter`, these deposits should be high)
-	pub const MigrationSignedDepositPerItem: Balance = CENTS;
-	pub const MigrationSignedDepositBase: Balance = 20 * CENTS * 100;
-	pub const MigrationMaxKeyLen: u32 = 512;
-}
-
-impl pallet_state_trie_migration::Config for Runtime {
-	type RuntimeHoldReason = RuntimeHoldReason;
-	type RuntimeEvent = RuntimeEvent;
-	type Currency = Balances;
-	type SignedDepositPerItem = MigrationSignedDepositPerItem;
-	type SignedDepositBase = MigrationSignedDepositBase;
-	type ControlOrigin = EnsureRoot<AccountId>;
-	type SignedFilter = frame_support::traits::NeverEnsureOrigin<AccountId>;
-
-	// Use same weights as substrate ones.
-	type WeightInfo = pallet_state_trie_migration::weights::SubstrateWeight<Runtime>;
-	type MaxKeyLen = MigrationMaxKeyLen;
-}
-
 /// The [frame_support::traits::tokens::ConversionFromAssetBalance] implementation provided by the
 /// `AssetRate` pallet instance.
 ///
@@ -1952,9 +1947,6 @@ construct_runtime! {
 		Crowdloan: crowdloan = 73,
 		Coretime: coretime = 74,
 
-		// State trie migration pallet, only temporary.
-		StateTrieMigration: pallet_state_trie_migration = 98,
-
 		// Pallet for sending XCM.
 		XcmPallet: pallet_xcm = 99,
 
@@ -2021,19 +2013,29 @@ pub type TxExtension = (
 pub mod migrations {
 	use super::*;
 
+	frame_support::parameter_types! {
+		pub const StateTrieMigrationName: &'static str = "StateTrieMigration";
+	}
+
+	/// Remove the retired `StateTrieMigration` pallet's storage, following upstream:
+	///
+	/// <https://github.com/polkadot-fellows/runtimes/issues/905>.
+	pub type RemoveStateTrieMigrationPallet = frame_support::migrations::RemovePallet<
+		StateTrieMigrationName,
+		<Runtime as frame_system::Config>::DbWeight,
+	>;
+
 	/// Unreleased migrations. Add new ones here:
 	pub type Unreleased = (
 		parachains_on_demand::migration::MigrateV1ToV2<Runtime>,
 		parachains_scheduler::migration::MigrateV3ToV4<Runtime>,
 		parachains_configuration::migration::v13::MigrateToV13<Runtime>,
 		parachains_shared::migration::MigrateToV2<Runtime>,
+		RemoveStateTrieMigrationPallet,
 	);
 
-	/// Migrations/checks that do not need to be versioned and can run on every update.
-	pub type Permanent = pallet_xcm::migration::MigrateToLatestXcmVersion<Runtime>;
-
 	/// All migrations that will run on the next runtime upgrade.
-	pub type SingleBlockMigrations = (Unreleased, Permanent);
+	pub type SingleBlockMigrations = Unreleased;
 }
 
 /// Unchecked extrinsic type as expected by this runtime.
@@ -2085,7 +2087,6 @@ mod benches {
 		[pallet_indices, Indices]
 		[pallet_message_queue, MessageQueue]
 		[pallet_multisig, Multisig]
-		[pallet_nomination_pools, NominationPoolsBench::<Runtime>]
 		[pallet_offences, OffencesBench::<Runtime>]
 		[pallet_parameters, Parameters]
 		[pallet_preimage, Preimage]
@@ -2121,7 +2122,6 @@ mod benches {
 		extensions::Pallet as SystemExtensionsBench, Pallet as SystemBench,
 	};
 	pub use pallet_election_provider_support_benchmarking::Pallet as ElectionProviderBench;
-	pub use pallet_nomination_pools_benchmarking::Pallet as NominationPoolsBench;
 	pub use pallet_offences_benchmarking::Pallet as OffencesBench;
 	pub use pallet_session_benchmarking::Pallet as SessionBench;
 	pub use pallet_xcm::benchmarking::Pallet as PalletXcmExtrinsicsBenchmark;
@@ -2138,7 +2138,6 @@ mod benches {
 	impl pallet_election_provider_support_benchmarking::Config for Runtime {}
 	impl frame_system_benchmarking::Config for Runtime {}
 	impl frame_benchmarking::baseline::Config for Runtime {}
-	impl pallet_nomination_pools_benchmarking::Config for Runtime {}
 	impl runtime_parachains::disputes::slashing::benchmarking::Config for Runtime {}
 
 	parameter_types! {
@@ -2199,6 +2198,11 @@ mod benches {
 
 		fn get_asset() -> Asset {
 			Asset { id: AssetId(Location::here()), fun: Fungible(ExistentialDeposit::get()) }
+		}
+
+		/// `Utility::batch`, so weighing a `Transact` recurses over every nested call.
+		fn batch_call(calls: Vec<RuntimeCall>) -> Option<RuntimeCall> {
+			Some(RuntimeCall::Utility(pallet_utility::Call::<Runtime>::batch { calls }))
 		}
 	}
 
@@ -2309,8 +2313,10 @@ mod benches {
 
 		fn alias_origin() -> Result<(Location, Location), BenchmarkError> {
 			let origin = Location::new(0, [Parachain(1000)]);
-			let target =
-				Location::new(0, [Parachain(1000), AccountId32 { id: [128u8; 32], network: None }]);
+			let target = Location::new(
+				0,
+				[Parachain(1000), Junction::AccountId32 { id: [128u8; 32], network: None }],
+			);
 			Ok((origin, target))
 		}
 	}
@@ -3565,53 +3571,29 @@ mod remote_tests {
 	use super::*;
 	use frame_try_runtime::{runtime_decl_for_try_runtime::TryRuntime, UpgradeCheckSelect};
 	use remote_externalities::{
-		Builder, Mode, OfflineConfig, OnlineConfig, RemoteExternalities, SnapshotConfig, Transport,
+		Builder, Mode, OfflineConfig, OnlineConfig, RemoteExternalities, SnapshotConfig,
 	};
 	use std::env::var;
 
 	async fn remote_ext_test_setup() -> RemoteExternalities<Block> {
-		let transport: Transport =
-			var("WS").unwrap_or("wss://paseo-rpc.dwellir.com".to_string()).into();
+		let transport: String = var("WS").unwrap_or("wss://paseo-rpc.dwellir.com".to_string());
 		let maybe_state_snapshot: Option<SnapshotConfig> = var("SNAP").map(|s| s.into()).ok();
 		Builder::<Block>::default()
 			.mode(if let Some(state_snapshot) = maybe_state_snapshot {
 				Mode::OfflineOrElseOnline(
 					OfflineConfig { state_snapshot: state_snapshot.clone() },
 					OnlineConfig {
-						transport,
+						transport_uris: vec![transport],
 						state_snapshot: Some(state_snapshot),
 						..Default::default()
 					},
 				)
 			} else {
-				Mode::Online(OnlineConfig { transport, ..Default::default() })
+				Mode::Online(OnlineConfig { transport_uris: vec![transport], ..Default::default() })
 			})
 			.build()
 			.await
 			.unwrap()
-	}
-
-	#[tokio::test]
-	#[ignore = "this test is meant to be executed manually"]
-	async fn validators_who_cannot_afford_session_key_deposit() {
-		use frame_support::traits::fungible::InspectHold;
-		sp_tracing::try_init_simple();
-		let mut ext = remote_ext_test_setup().await;
-		ext.execute_with(|| {
-			let amount = <Runtime as pallet_session::Config>::KeyDeposit::get();
-			let reason = pallet_session::HoldReason::Keys;
-			let cannot_pay = pallet_staking::Validators::<Runtime>::iter()
-				.map(|(v, _prefs)| v)
-				.filter(|v| {
-					pallet_balances::Pallet::<Runtime>::ensure_can_hold(&reason.into(), v, amount)
-						.is_err()
-				})
-				.collect::<Vec<_>>();
-
-			for v in cannot_pay {
-				log::warn!(target: "runtime", "validator {v:?} cannot pay a deposit of {amount:?}")
-			}
-		})
 	}
 
 	#[tokio::test]
@@ -3689,11 +3671,10 @@ mod remote_tests {
 		}
 		use hex_literal::hex;
 		sp_tracing::try_init_simple();
-		let transport: Transport =
-			var("WS").unwrap_or("wss://rpc.dotters.network/paseo".to_string()).into();
+		let transport: String = var("WS").unwrap_or("wss://rpc.dotters.network/paseo".to_string());
 		let mut ext = Builder::<Block>::default()
 			.mode(Mode::Online(OnlineConfig {
-				transport,
+				transport_uris: vec![transport],
 				hashed_prefixes: vec![
 					// staking eras total stake
 					hex!("5f3e4907f716ac89b6347d15ececedcaa141c4fe67c2d11f4a10c6aca7a79a04")
@@ -3878,6 +3859,111 @@ mod proxy_tests {
 						)),
 				"Carol should no longer be Alice's StakingOperator proxy"
 			);
+		});
+	}
+}
+
+#[cfg(test)]
+mod post_ahm_filter_tests {
+	use super::*;
+	use sp_runtime::traits::Dispatchable;
+
+	fn new_test_ext() -> sp_io::TestExternalities {
+		frame_system::GenesisConfig::<Runtime>::default()
+			.build_storage()
+			.unwrap()
+			.into()
+	}
+
+	#[test]
+	fn staking_is_blocked() {
+		new_test_ext().execute_with(|| {
+			let call = RuntimeCall::Staking(pallet_staking::Call::bond {
+				value: 100,
+				payee: pallet_staking::RewardDestination::Staked,
+			});
+
+			let origin = RuntimeOrigin::signed(AccountId::from([1u8; 32]));
+			let result = call.dispatch(origin);
+
+			assert_eq!(
+				result.unwrap_err().error,
+				frame_system::Error::<Runtime>::CallFiltered.into(),
+			);
+		});
+	}
+
+	/// Session keys are managed via Asset Hub post-AHM, so the direct relay `set_keys`/`purge_keys`
+	/// extrinsics must be rejected by the base call filter (closing the free-registration spam
+	/// vector, #1200).
+	#[test]
+	fn session_set_keys_and_purge_keys_are_blocked() {
+		use codec::Decode;
+		new_test_ext().execute_with(|| {
+			// `SessionKeys` is not `Default`; decode a zero-filled buffer to obtain an instance
+			// (the field values are irrelevant to the filter, which matches on the call variant).
+			let keys = SessionKeys::decode(&mut &[0u8; 512][..]).expect("decodes into SessionKeys");
+			let origin = RuntimeOrigin::signed(AccountId::from([1u8; 32]));
+
+			for call in [
+				RuntimeCall::Session(pallet_session::Call::set_keys {
+					keys,
+					proof: Default::default(),
+				}),
+				RuntimeCall::Session(pallet_session::Call::purge_keys {}),
+			] {
+				assert_eq!(
+					call.dispatch(origin.clone()).unwrap_err().error,
+					frame_system::Error::<Runtime>::CallFiltered.into(),
+				);
+			}
+		});
+	}
+
+	#[test]
+	fn transfer_is_allowed() {
+		new_test_ext().execute_with(|| {
+			let sender = AccountId::from([1u8; 32]);
+			let dest = AccountId::from([0u8; 32]);
+
+			// Fund the sender.
+			pallet_balances::Pallet::<Runtime>::force_set_balance(
+				RuntimeOrigin::root(),
+				sp_runtime::MultiAddress::Id(sender.clone()),
+				1_000_000_000_000,
+			)
+			.unwrap();
+
+			let call = RuntimeCall::Balances(pallet_balances::Call::transfer_allow_death {
+				dest: sp_runtime::MultiAddress::Id(dest),
+				value: 100_000_000_000,
+			});
+
+			let origin = RuntimeOrigin::signed(sender);
+			assert!(call.dispatch(origin).is_ok());
+		});
+	}
+}
+
+#[cfg(test)]
+mod upgrade_tests {
+	use super::*;
+	use frame_support::traits::OnRuntimeUpgrade;
+
+	#[test]
+	fn retired_trie_migration_storage_is_removed_without_touching_other_pallets() {
+		sp_io::TestExternalities::default().execute_with(|| {
+			let mut retired_key = sp_io::hashing::twox_128(b"StateTrieMigration").to_vec();
+			retired_key.extend_from_slice(&sp_io::hashing::twox_128(b"MigrationProcess"));
+			let mut retained_key = sp_io::hashing::twox_128(b"System").to_vec();
+			retained_key.extend_from_slice(&sp_io::hashing::twox_128(b"Number"));
+			sp_io::storage::set(&retired_key, &[1]);
+			sp_io::storage::set(&retained_key, &[2]);
+
+			migrations::RemoveStateTrieMigrationPallet::on_runtime_upgrade();
+
+			assert!(!sp_io::storage::exists(&retired_key));
+			assert_eq!(sp_io::storage::get(&retained_key).unwrap().as_ref(), &[2]);
 		});
 	}
 }


### PR DESCRIPTION
Align the Paseo relay chain with the Polkadot relay changes from [Fellowship v2.5.0](https://github.com/polkadot-fellows/runtimes/releases/tag/v2.5.0), setting `spec_version` to `2_005_000`.

- Update the relay's header limit, post-AHM session-key filter, migrations, and benchmark configuration.
- Define the required dependencies in the root `Cargo.toml`, retain `workspace = true` in the relay manifest, and align dependent Cumulus and test utilities.
- Preserve Paseo-specific configuration. System-chain source and `spec_version` values remain unchanged, but shared dependency updates affect their workspace consumers.

**Note:** Weights have not been updated; the approach will be confirmed with the team and handled separately.

Validation from review: the block-length regression test and retired-pallet storage cleanup test pass. Extrinsic limits remain 5 MiB (Operational/Mandatory) and 3.75 MiB (Normal); the header cap is 100 KiB. Fixed the remote test's default RPC hostname.

Tested the native try-runtime migration test (`PreAndPost`) with `wss://rpc-paseo.stakeworld.io`: passed against a fresh live-state snapshot in 39.68 seconds. No WASM/Chopsticks dry-run has been completed.

To reproduce with an archive RPC (use a new snapshot path for fresh state):
```sh
RUN_MIGRATION_TESTS=1 WS=wss://rpc-paseo.stakeworld.io \
SNAP=/tmp/paseo-upgrade.snap SKIP_WASM_BUILD=1 \
cargo +1.93.0 test -p paseo-runtime --lib --features try-runtime \
  remote_tests::run_migrations --locked -- --exact --nocapture
```

