### PR TITLE
fix(people,asset-hub): pin RelayParentOffset to 0

### DIFF
--- a/system-parachains/asset-hub-paseo/src/lib.rs
+++ b/system-parachains/asset-hub-paseo/src/lib.rs
@@ -160,9 +160,7 @@ use system_parachains_constants::{
 	},
 	paseo::{
 		consensus::{
-			elastic_scaling::{
-				BLOCK_PROCESSING_VELOCITY, RELAY_PARENT_OFFSET, UNINCLUDED_SEGMENT_CAPACITY,
-			},
+			elastic_scaling::{BLOCK_PROCESSING_VELOCITY, UNINCLUDED_SEGMENT_CAPACITY},
 			RELAY_CHAIN_SLOT_DURATION_MILLIS,
 		},
 		currency::*,
@@ -884,6 +882,24 @@ parameter_types! {
 	pub const ReservedDmpWeight: Weight = MAXIMUM_BLOCK_WEIGHT.saturating_div(4);
 	pub const RelayOrigin: AggregateMessageOrigin = AggregateMessageOrigin::Parent;
 }
+
+/// PASEO-LOCAL OVERRIDE, pinned to 0.
+///
+/// `system_parachains_constants::paseo::consensus::elastic_scaling::RELAY_PARENT_OFFSET` is 1.
+/// Building one relay block behind makes the collator request **claim queue offset 2**
+/// (`relay_parent_offset + 1`), and enacting spec 2_005_000 on people-paseo froze the chain: the
+/// collator could not get a candidate backed and fell back to building on the last finalized
+/// block, where `cumulus-pallet-parachain-system` panics with
+/// `assertion failed: Only 1 is supported as valid claim queue offset -- left: 2, right: 1`.
+///
+/// Every other Paseo system parachain -- bulletin, coretime, collectives, bridge-hub -- already
+/// declares `RelayParentOffset = ConstU32<0>`, and bulletin took the same v2.5.0 release cleanly
+/// with offset 0. people-paseo and asset-hub-paseo were the only two on offset 1.
+///
+/// This pins both to 0 so they match the configuration that is known to work against the live
+/// Paseo relay. Revisit only alongside a relay-side change, and re-test on a fork whose relay
+/// matches production.
+const RELAY_PARENT_OFFSET: u32 = 0;
 
 impl cumulus_pallet_parachain_system::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;

--- a/system-parachains/people-paseo/src/lib.rs
+++ b/system-parachains/people-paseo/src/lib.rs
@@ -85,9 +85,7 @@ use system_parachains_constants::{
 	async_backing::{MAXIMUM_BLOCK_WEIGHT, NORMAL_DISPATCH_RATIO},
 	paseo::{
 		consensus::{
-			elastic_scaling::{
-				BLOCK_PROCESSING_VELOCITY, RELAY_PARENT_OFFSET, UNINCLUDED_SEGMENT_CAPACITY,
-			},
+			elastic_scaling::{BLOCK_PROCESSING_VELOCITY, UNINCLUDED_SEGMENT_CAPACITY},
 			RELAY_CHAIN_SLOT_DURATION_MILLIS,
 		},
 		currency::*,
@@ -321,6 +319,24 @@ parameter_types! {
 	pub const ReservedDmpWeight: Weight = MAXIMUM_BLOCK_WEIGHT.saturating_div(4);
 	pub const RelayOrigin: AggregateMessageOrigin = AggregateMessageOrigin::Parent;
 }
+
+/// PASEO-LOCAL OVERRIDE, pinned to 0.
+///
+/// `system_parachains_constants::paseo::consensus::elastic_scaling::RELAY_PARENT_OFFSET` is 1.
+/// Building one relay block behind makes the collator request **claim queue offset 2**
+/// (`relay_parent_offset + 1`), and enacting spec 2_005_000 on people-paseo froze the chain: the
+/// collator could not get a candidate backed and fell back to building on the last finalized
+/// block, where `cumulus-pallet-parachain-system` panics with
+/// `assertion failed: Only 1 is supported as valid claim queue offset -- left: 2, right: 1`.
+///
+/// Every other Paseo system parachain -- bulletin, coretime, collectives, bridge-hub -- already
+/// declares `RelayParentOffset = ConstU32<0>`, and bulletin took the same v2.5.0 release cleanly
+/// with offset 0. people-paseo and asset-hub-paseo were the only two on offset 1.
+///
+/// This pins both to 0 so they match the configuration that is known to work against the live
+/// Paseo relay. Revisit only alongside a relay-side change, and re-test on a fork whose relay
+/// matches production.
+const RELAY_PARENT_OFFSET: u32 = 0;
 
 impl cumulus_pallet_parachain_system::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;


### PR DESCRIPTION
Recovery fix for the people-paseo stall at block **6546979**.

## What happened

Enacting spec `2_005_000` on people-paseo froze the chain. The collator built and imported the block
carrying the new code, but the relay never promoted `futureCodeHash` → `currentCodeHash`:

```
Parachain code doesn't match validation code stored in the relay chain state. para_id=1004
Collation wasn't advertised to any validator.
```

It then fell back to authoring on the last finalized block and panicked:

```
cumulus-pallet-parachain-system-0.28.0/src/lib.rs:606
assertion `left == right` failed: Only 1 is supported as valid claim queue offset
  left: 2, right: 1
```

`RelayParentOffsetApi::relay_parent_offset()` is what the collator queries to decide how far behind
the relay to build. It returned `RELAY_PARENT_OFFSET` = 1, which requests claim queue offset 2.

## Why this fix

**people-paseo and asset-hub-paseo were the only two Paseo system parachains on offset 1.** bulletin,
coretime, collectives and bridge-hub all declare `RelayParentOffset = ConstU32<0>` — and **bulletin
took the very same v2.5.0 release cleanly**. This pins people and asset-hub to 0, matching the
configuration proven to work against the live Paseo relay.

Both the `Config` associated type and the `RelayParentOffsetApi` runtime API resolve through a single
local constant, so they cannot drift apart.

`UNINCLUDED_SEGMENT_CAPACITY` is deliberately left on the shared `elastic_scaling` value — a larger
unincluded segment than the offset requires is a harmless upper bound, and this keeps exactly one
variable moving.

## `spec_version` is deliberately NOT bumped

people-paseo already has `2_005_000` applied on chain. Recovery is via `codeSubstitutes` on the
collators, which stays active *until the on-chain `spec_version` changes* — so holding it at
`2_005_000` is what keeps the substitute effective.

## Why testing missed it

`RELAY_PARENT_OFFSET` is `1` in production but `0` under `#[cfg(feature = "try-runtime")]`. Every
try-runtime dry-run therefore exercised offset 0 — the working configuration. The zombie-bite fork
missed it too: its relay is built from the same source tree as the parachains, so no relay/parachain
skew exists there. **Re-test relay-skew-sensitive changes on a fork whose relay matches production.**