### PR TITLE
ci(release): pin the pop-cli tap and retry the install

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -343,8 +343,33 @@ jobs:
           echo "/home/linuxbrew/.linuxbrew/bin" >> $GITHUB_PATH
 
       - name: Install Pop
+        env:
+          # Pin the tap to the commit that adds pop-cli v0.12.1. The tap ships a single
+          # unversioned `pop.rb`, so there is no `pop@X.Y.Z` formula to pin by name: the only
+          # way to hold a version is to check the tap out at a fixed commit and stop brew from
+          # auto-updating it back to HEAD.
+          POP_TAP_COMMIT: 6d69ca334a23aded8e43ae9989afda358de4d32d
+          HOMEBREW_NO_AUTO_UPDATE: 1
+          HOMEBREW_NO_INSTALL_FROM_API: 1
         run: |
-          brew install r0gue-io/pop-cli/pop
+          set -euo pipefail
+          brew tap r0gue-io/pop-cli
+          git -C "$(brew --repository r0gue-io/pop-cli)" checkout -q "$POP_TAP_COMMIT"
+
+          # `create-release` needs this job, so a transient install failure blocks the whole
+          # release even when every runtime built. Release v2.5.0 was lost exactly that way:
+          # `brew install r0gue-io/pop-cli/pop` exited 1 with "Broken pipe" while fetching.
+          # Pinning fixes which version we get, not the flaky fetch, so retry the install.
+          for attempt in 1 2 3; do
+            if brew install --formula r0gue-io/pop-cli/pop; then
+              pop --version
+              exit 0
+            fi
+            echo "::warning::pop install attempt ${attempt} failed; retrying in 15s"
+            sleep 15
+          done
+          echo "::error::pop install failed after 3 attempts"
+          exit 1
 
       - name: Generate chain specs
         run: |


### PR DESCRIPTION
The release workflow lost `v2.5.0` on a dependency install, not on anything to do with the runtimes.

`create-release` declares `needs: [create-tag, generate-chain-specs, build-runtimes]`, so `generate-chain-specs` is a hard gate. In run `34250873447` all ten runtime jobs succeeded and the wasm blobs built fine, but the release was never created because this step exited 1:

```
==> Installing pop from r0gue-io/pop-cli
##[error]r0gue-io/pop-cli/pop: Broken pipe
##[error]Process completed with exit code 1
```

## Changes

**Pin the version.** The tap ships a single unversioned `pop.rb`, so there is no `pop@X.Y.Z` formula to pin by name. The only way to hold a version is to check the tap out at a fixed commit (`6d69ca33`, the commit that adds pop-cli v0.12.1) and set `HOMEBREW_NO_AUTO_UPDATE` / `HOMEBREW_NO_INSTALL_FROM_API` so brew cannot quietly drift back to tap HEAD.

**Retry the install.** Worth being explicit: pinning fixes *which* version we get, it does not fix the flaky fetch that actually broke the release. A pinned formula would have hit the same broken pipe. The install is therefore retried three times with a short backoff, and the step fails loudly if all three fail.

## Not addressed here

The job still bootstraps all of Homebrew on a Linux runner just to fetch one binary, when pop-cli publishes `pop-x86_64-unknown-linux-gnu.tar.gz` directly. Replacing the bootstrap with a direct download would remove this failure mode rather than retry through it, but that is a larger change than this fix wants to be.