### PR TITLE
fix(people): bump spec_version to 2_005_001 to retire the codeSubstitute

### DIFF
--- a/system-parachains/people-paseo/src/lib.rs
+++ b/system-parachains/people-paseo/src/lib.rs
@@ -185,7 +185,26 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: Cow::Borrowed("people-paseo"),
 	impl_name: Cow::Borrowed("people-paseo"),
 	authoring_version: 1,
-	spec_version: 2_005_000,
+	// 2_005_000 -> 2_005_001 is NOT hygiene: it retires a `codeSubstitutes` entry.
+	//
+	// The 2_005_000 build that enacted on people-paseo carried `RelayParentOffset = 1`, which
+	// halted the chain at #6546979 (`InvalidNumberOfDescendants { expected: 2, received: 0 }`).
+	// Recovery registered a corrected offset-0 blob on the relay via
+	// `paras.forceSetCurrentCode`, and node operators run a spec carrying
+	// `codeSubstitutes { "6546979": <that blob> }`. So TWO DIFFERENT WASM BLOBS BOTH CLAIM
+	// spec_version 2_005_000: the broken one still sitting in this chain's `:code`, and the
+	// substitute that nodes actually execute.
+	//
+	// `sc_service`'s substitute map is keyed by the substitute's own `spec_version` and applies
+	// only where the on-chain runtime reports that same version, so leaving this at 2_005_000
+	// would keep every node permanently dependent on holding that spec file. Bumping to
+	// 2_005_001 puts the corrected code in `:code` under a version no substitute claims, and
+	// nodes past this upgrade need no substitute at all.
+	//
+	// The `codeSubstitutes` entry must nevertheless stay in the distributed spec forever: blocks
+	// 6546979..<this upgrade> can only be replayed with it, so any archive or resyncing node
+	// still needs it to cross that range.
+	spec_version: 2_005_001,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	// BUMPED 1 -> 2 for the individuality v0.3.1 port. MANDATORY, not hygiene: coinage call


### PR DESCRIPTION
Brings `main` back in line with what people-paseo is actually running. **This runtime is already live on chain** — see below.

## Why

The `2_005_000` build that enacted on people-paseo carried `RelayParentOffset = 1` and halted the chain at `#6546979`:

```
InvalidNumberOfDescendants { expected: 2, received: 0 }
```

Recovery registered a corrected offset-0 blob on the relay with `paras.forceSetCurrentCode`, and node operators run a spec carrying `codeSubstitutes { "6546979": <that blob> }`.

That leaves **two different wasm blobs both claiming `spec_version` 2_005_000**: the broken one sitting in the chain’s `:code`, and the substitute that nodes actually execute.

`sc_service` keys its substitute map by the substitute’s own `spec_version` and applies it only where the on-chain runtime reports that same version:

```rust
let spec_version = version.spec_version;      // key = the SUBSTITUTE’s version
let s = self.substitutes.get(&spec)?;         // looked up by the ON-CHAIN version
Some(self.block_number) <= requested_block_number
```

So holding at 2_005_000 would make every node — RPC providers included, not just collators — permanently dependent on shipping that spec file. 2_005_001 puts the corrected code in `:code` under a version no substitute claims.

## The codeSubstitutes entry still has to ship

Bumping the spec does **not** retire the substitute retroactively. Blocks `6546979..6548143` can only be replayed with it, so any archive node, or any node syncing from genesis, still needs it to cross that range. It must stay in the distributed spec permanently. Nodes can alternatively warp-sync with the stock spec, which lands at tip on 2_005_001 and skips the range entirely.

## Migrations

No migration content changes, and the tuple is deliberately left as-is. Re-running it is a no-op:

- `SeedNetworkSuffix`, `CreatePeopleCollection`, `CreateLitePeopleCollection` — self-guarding, no-op when already applied
- `SeedCoinageInstanceZero` — guarded on `Instances::contains_key(LEGACY_INSTANCE_ID)`
- `score::MigrateV0ToV1`, `origin_restriction::MigrateV0ToV1` — wrapped in `VersionedMigration`, StorageVersion-gated
- `ring_roots::MigrateRingRootsToCommitmentOnly` — length-guarded, migrated entries are 288 bytes and fail the `< OLD_MEMBERS_LEN` check
- both MBMs — recorded in `pallet_migrations::Historic` and skipped

Leaving them in place is also the *correct* choice rather than merely a safe one: removing an MBM whose cursor is still live would strand it. Verified on chain before upgrading — `cursor: None`, and `historic` lists `paseo-coinage-to-instances`, `paseo-coinage-relocate-recycler-`, `foreign-assets-reserves`, `pallet-identity` as complete.

## Already enacted

Built with srtool (`v0.18.4`, rustc 1.93.0, `paritytech/srtool:1.93.0`, profile `production`, `--features on-chain-release-build`):

```
specVersion         2005001            transactionVersion 2 (unchanged)
compressed size     1,925,394 bytes
blake2_256          0xfa5e746b7259049246ff38de55591690115df6e38522464c497027cdf562f41f
```

`authorizeUpgrade` + `applyAuthorizedUpgrade` landed, and the relay promoted it: `paras.currentCodeHash(1004) == 0xfa5e746b…`, `futureCodeHash` cleared. people-paseo is producing on 2_005_001.

Merging this makes `main` match the chain.