### PR TITLE
fix(asset-hub): keep the shared RelayParentOffset of 1

### DIFF
--- a/system-parachains/asset-hub-paseo/src/lib.rs
+++ b/system-parachains/asset-hub-paseo/src/lib.rs
@@ -160,7 +160,9 @@ use system_parachains_constants::{
 	},
 	paseo::{
 		consensus::{
-			elastic_scaling::{BLOCK_PROCESSING_VELOCITY, UNINCLUDED_SEGMENT_CAPACITY},
+			elastic_scaling::{
+				BLOCK_PROCESSING_VELOCITY, RELAY_PARENT_OFFSET, UNINCLUDED_SEGMENT_CAPACITY,
+			},
 			RELAY_CHAIN_SLOT_DURATION_MILLIS,
 		},
 		currency::*,
@@ -882,24 +884,6 @@ parameter_types! {
 	pub const ReservedDmpWeight: Weight = MAXIMUM_BLOCK_WEIGHT.saturating_div(4);
 	pub const RelayOrigin: AggregateMessageOrigin = AggregateMessageOrigin::Parent;
 }
-
-/// PASEO-LOCAL OVERRIDE, pinned to 0.
-///
-/// `system_parachains_constants::paseo::consensus::elastic_scaling::RELAY_PARENT_OFFSET` is 1.
-/// Building one relay block behind makes the collator request **claim queue offset 2**
-/// (`relay_parent_offset + 1`), and enacting spec 2_005_000 on people-paseo froze the chain: the
-/// collator could not get a candidate backed and fell back to building on the last finalized
-/// block, where `cumulus-pallet-parachain-system` panics with
-/// `assertion failed: Only 1 is supported as valid claim queue offset -- left: 2, right: 1`.
-///
-/// Every other Paseo system parachain -- bulletin, coretime, collectives, bridge-hub -- already
-/// declares `RelayParentOffset = ConstU32<0>`, and bulletin took the same v2.5.0 release cleanly
-/// with offset 0. people-paseo and asset-hub-paseo were the only two on offset 1.
-///
-/// This pins both to 0 so they match the configuration that is known to work against the live
-/// Paseo relay. Revisit only alongside a relay-side change, and re-test on a fork whose relay
-/// matches production.
-const RELAY_PARENT_OFFSET: u32 = 0;
 
 impl cumulus_pallet_parachain_system::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;


### PR DESCRIPTION
Reverts the **asset-hub half** of #416. people-paseo keeps its local override of `0`; only asset-hub goes back to the shared constant.

## Why

#416 pinned both people-paseo and asset-hub-paseo to `0`, on the theory that offset 1 was what froze people-paseo at `#6546979`. That inference does not carry over to asset-hub.

Read from chain, asset-hub-paseo today:

```
spec 2004002   relay_parent_offset -> 1        (runtime API, executed against live state)
:code 0x73bb1c81…  ==  relay paras.currentCodeHash(1000)     chain and relay agree
```

and its candidates are observed being backed at a relay-parent lag of 2, measured from relay `paraInclusion` events over 25 blocks:

```
asset-hub (para 1000)   declares 1   observed lag  min 2, max 3
people    (para 1004)   declares 0   observed lag  min 1, max 2
```

So asset-hub is honouring offset 1 right now, in production, without trouble. people-paseo and asset-hub run different collators, and the failure was in that layer — the panic (`Only 1 is supported as valid claim queue offset`) came from the collator, not from chain state.

Enacting 2_005_000 on asset-hub should not also change its consensus timing. This keeps the upgrade to runtime and migration content, and leaves relay-parent behaviour exactly as it is today.

## Note on the shared constant

```rust
#[cfg(not(feature = "try-runtime"))]
pub const RELAY_PARENT_OFFSET: u32 = 1;
#[cfg(feature = "try-runtime")]
pub const RELAY_PARENT_OFFSET: u32 = 0;
```

A production release build takes the `1` arm, which is what asset-hub runs today. Both the `Config` type and the `RelayParentOffsetApi` impl read the same constant, so they cannot disagree.

`UNINCLUDED_SEGMENT_CAPACITY` is computed inside the constants module from the module’s own `RELAY_PARENT_OFFSET`, so it was 12 before and after #416; this revert does not move it either.

## Effect on the release

The v2.5.1 asset-hub artifact (`0x12fa410a…`, offset 0) should not be enacted. asset-hub needs a rebuild from this commit; people-paseo 2_005_001 in v2.5.1 is already live on chain and is unaffected.