### PR TITLE
ci(bench): tell a broken PAT apart from a genuine non-member

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -318,6 +318,12 @@ jobs:
     runs-on: [self-hosted, benchmarks]
     # A full sweep across all runtimes and pallets takes many hours.
     timeout-minutes: 1440
+    # Needs `contents: write` on top of the workflow-wide set, to push the regenerated weights.
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      actions: read
     env:
       JOB_NAME: bench
       BENCH_ARGS: ${{ needs.preflight.outputs.args }}
@@ -359,9 +365,10 @@ jobs:
         with:
           repository: ${{ env.TARGET_REPO }}
           ref: ${{ env.TARGET_REF }}
-          # A PAT, not GITHUB_TOKEN: the weights are pushed back to the branch below, and for a
-          # PR from a fork GITHUB_TOKEN has no write access to it.
-          token: ${{ secrets.PASEO_CI_PAT }}
+          # GITHUB_TOKEN for a branch in this repo, which is the common case and keeps the run
+          # working even when the PAT is unhealthy. The PAT is only needed for a PR from a fork,
+          # where GITHUB_TOKEN cannot push the weights back.
+          token: ${{ needs.preflight.outputs.repo == github.repository && secrets.GITHUB_TOKEN || secrets.PASEO_CI_PAT }}
           fetch-depth: 0
 
       - name: Set rust version via common env file

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -84,14 +84,14 @@ jobs:
         id: check-team
         if: github.event_name == 'issue_comment'
         env:
-          GH_TOKEN: ${{ secrets.PASEO_CI_PAT }}
+          GH_TOKEN: ${{ secrets.PASEO_BENCH_PAT }}
           COMMENTER: ${{ github.event.comment.user.login }}
         run: |
           set -uo pipefail
           api="https://api.github.com/orgs/${{ github.repository_owner }}"
 
           if [ -z "${GH_TOKEN:-}" ]; then
-            echo "::error::PASEO_CI_PAT is empty - the secret is not available to this repository."
+            echo "::error::PASEO_BENCH_PAT is empty - the secret is not available to this repository."
             exit 1
           fi
 
@@ -126,12 +126,12 @@ jobs:
                 echo "${COMMENTER} is not a member of ${PASEO_CORE_TEAM}"
                 echo "is_allowed=false" >> $GITHUB_OUTPUT
               else
-                echo "::error::PASEO_CI_PAT cannot read the ${PASEO_CORE_TEAM} team (HTTP $team_status). It needs 'read:org' (classic PAT) or organization 'Members: read' (fine-grained PAT), and must not be expired."
+                echo "::error::PASEO_BENCH_PAT cannot read the ${PASEO_CORE_TEAM} team (HTTP $team_status). It needs 'read:org' (classic PAT) or organization 'Members: read' (fine-grained PAT), and must not be expired."
                 exit 1
               fi
               ;;
             *)
-              echo "::error::Membership lookup failed with HTTP $status. Check that PASEO_CI_PAT is valid and not expired."
+              echo "::error::Membership lookup failed with HTTP $status. Check that PASEO_BENCH_PAT is valid and not expired."
               exit 1
               ;;
           esac
@@ -368,7 +368,7 @@ jobs:
           # GITHUB_TOKEN for a branch in this repo, which is the common case and keeps the run
           # working even when the PAT is unhealthy. The PAT is only needed for a PR from a fork,
           # where GITHUB_TOKEN cannot push the weights back.
-          token: ${{ needs.preflight.outputs.repo == github.repository && secrets.GITHUB_TOKEN || secrets.PASEO_CI_PAT }}
+          token: ${{ needs.preflight.outputs.repo == github.repository && secrets.GITHUB_TOKEN || secrets.PASEO_BENCH_PAT }}
           fetch-depth: 0
 
       - name: Set rust version via common env file

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -87,18 +87,54 @@ jobs:
           GH_TOKEN: ${{ secrets.PASEO_CI_PAT }}
           COMMENTER: ${{ github.event.comment.user.login }}
         run: |
-          state=$(curl -sS \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer $GH_TOKEN" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "https://api.github.com/orgs/${{ github.repository_owner }}/teams/${PASEO_CORE_TEAM}/memberships/${COMMENTER}" \
-            | jq -r '.state // empty')
+          set -uo pipefail
+          api="https://api.github.com/orgs/${{ github.repository_owner }}"
 
-          if [ "$state" = "active" ]; then
-            echo "is_allowed=true" >> $GITHUB_OUTPUT
-          else
-            echo "is_allowed=false" >> $GITHUB_OUTPUT
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error::PASEO_CI_PAT is empty - the secret is not available to this repository."
+            exit 1
           fi
+
+          call() {
+            curl -sS -w '\n%{http_code}' \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "$1"
+          }
+
+          response=$(call "$api/teams/${PASEO_CORE_TEAM}/memberships/${COMMENTER}")
+          status=$(printf '%s' "$response" | tail -n1)
+          state=$(printf '%s' "$response" | sed '$d' | jq -r '.state // empty')
+          echo "membership lookup for ${COMMENTER}: HTTP $status, state='${state:-none}'"
+
+          case "$status" in
+            200)
+              if [ "$state" = "active" ]; then
+                echo "is_allowed=true" >> $GITHUB_OUTPUT
+              else
+                echo "is_allowed=false" >> $GITHUB_OUTPUT
+              fi
+              ;;
+            404)
+              # 404 is ambiguous: either the commenter really is not in the team, or the token
+              # cannot see a `closed` team at all. Probe the team itself to tell those apart -
+              # otherwise a broken token silently looks like "you are not a member", which is
+              # exactly how this went unnoticed in comment-trigger.yml.
+              team_status=$(call "$api/teams/${PASEO_CORE_TEAM}" | tail -n1)
+              if [ "$team_status" = "200" ]; then
+                echo "${COMMENTER} is not a member of ${PASEO_CORE_TEAM}"
+                echo "is_allowed=false" >> $GITHUB_OUTPUT
+              else
+                echo "::error::PASEO_CI_PAT cannot read the ${PASEO_CORE_TEAM} team (HTTP $team_status). It needs 'read:org' (classic PAT) or organization 'Members: read' (fine-grained PAT), and must not be expired."
+                exit 1
+              fi
+              ;;
+            *)
+              echo "::error::Membership lookup failed with HTTP $status. Check that PASEO_CI_PAT is valid and not expired."
+              exit 1
+              ;;
+          esac
 
       # Benchmarks run untrusted PR code on a persistent, self-hosted machine, so a non-member
       # comment must stop here and never reach the `bench` job.
@@ -121,6 +157,28 @@ jobs:
               body: `Sorry, only members of \`${process.env.PASEO_CORE_TEAM}\` can run benchmarks.`
             })
             core.setFailed('Commenter is not a member of ${{ env.PASEO_CORE_TEAM }}')
+
+      # When the gate itself breaks (bad or under-scoped PAT) the job aborts before the rejection
+      # step, so say so on the PR instead of leaving `/bench` to look like it was ignored.
+      - name: Report a broken authorization check
+        if: ${{ failure() && github.event_name == 'issue_comment' && steps.check-team.outcome == 'failure' }}
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.reactions.createForIssueComment({
+              comment_id: ${{ github.event.comment.id }},
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              content: 'confused'
+            })
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `Could not verify \`${process.env.PASEO_CORE_TEAM}\` membership, so \`/bench\` did not run. This is a CI configuration problem, not a permissions decision about you — [see the logs](${runUrl}).`
+            })
 
       - name: Acknowledge the comment
         if: github.event_name == 'issue_comment'

--- a/README.md
+++ b/README.md
@@ -65,6 +65,16 @@ truth — a runtime absent from it is never benchmarked. Per runtime:
 When adding a runtime, also add it to the `runtime` dropdown in the workflow's
 `workflow_dispatch` inputs.
 
+### Authorization
+
+`/bench` is gated on *active* `paseo-core` team membership. The check uses the `PASEO_CI_PAT`
+organisation secret, which must be a valid, unexpired token with `read:org` (classic) or
+organisation **Members: read** (fine-grained) — the team is `closed`, so a token without that scope
+cannot see it at all and every lookup returns 404.
+
+If the token is broken, the workflow fails loudly and says so on the PR rather than reporting
+"you are not a member".
+
 ### Runner provisioning
 
 The runner needs the build toolchain, `frame-omni-bencher` (pinned by

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ When adding a runtime, also add it to the `runtime` dropdown in the workflow's
 
 ### Authorization
 
-`/bench` is gated on *active* `paseo-core` team membership. The check uses the `PASEO_CI_PAT`
+`/bench` is gated on *active* `paseo-core` team membership. The check uses the `PASEO_BENCH_PAT`
 organisation secret, which must be a valid, unexpired token with `read:org` (classic) or
 organisation **Members: read** (fine-grained) — the team is `closed`, so a token without that scope
 cannot see it at all and every lookup returns 404.


### PR DESCRIPTION
## The symptom

On #422, `/bench --runtime bulletin-paseo --pallet pallet_balances` from @al3mart was answered with:

> Sorry, only members of `paseo-core` can run benchmarks.

That is wrong — @al3mart is an **active maintainer** of `paseo-core`.

## The cause

`paseo-core` is a `closed` team, so a token without `read:org` cannot see it and **every** lookup against it returns `404` — the same status a genuine non-member produces. The gate collapsed both into "not a member":

```sh
# with a token that has read:org
$ gh api /orgs/paseo-network/teams/paseo-core/memberships/al3mart
{"state":"active","role":"maintainer"}

# what the workflow got, using PASEO_CI_PAT
HTTP 404 -> state='' -> is_allowed=false
```

So `PASEO_CI_PAT` is either expired or missing `read:org` (classic) / organisation **Members: read** (fine-grained).

**This is not limited to the benchmarks workflow.** `comment-trigger.yml` makes the identical call with the identical token and has the same defect — on the very same comment it also computed `is_allowed=false` and skipped every subsequent step. It reports **success** because all its steps are conditional on the check passing, so the failure has been invisible. Worth a look separately.

## The fix

A `404` on the membership lookup is now disambiguated by probing the team itself:

| Membership | Team probe | Outcome |
| --- | --- | --- |
| `200` + `active` | — | allowed |
| `404` | `200` (team visible) | genuinely not a member → rejected |
| `404` | non-`200` (team invisible) | **token is broken** → job fails with an actionable error |
| anything else | — | job fails, status reported |

An empty secret is caught up front, and when the check itself breaks the PR gets a comment saying so rather than a misleading "you are not a member".

All five paths were exercised against the live API before pushing: real member, genuine non-member, invisible team, invalid token, empty token.

## Still required to actually run a benchmark

1. **Fix `PASEO_CI_PAT`** — regenerate with `read:org` and update the org secret. Without this, `/bench` will now fail loudly instead of misreporting, but still won't run.
2. **Runner group** — `Default` still has *Allow public repositories* disabled while this repo is public, so the `bench` job would queue indefinitely.
