### PR TITLE
WIP: sync Bulletin runtime with upstream

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -289,7 +289,7 @@ pallet-utility = { version = "49.0.1", default-features = false }
 pallet-vesting = { version = "49.0.0", default-features = false }
 pallet-vesting-precompiles = { version = "0.5.0", default-features = false }
 pallet-whitelist = { version = "48.0.0", default-features = false }
-pallet-xcm = { version = "29.0.0", default-features = false }
+pallet-xcm = { version = "29.1.0", default-features = false }
 pallet-xcm-benchmarks = { version = "29.0.0", default-features = false }
 pallet-xcm-precompiles = { version = "0.9.0", default-features = false }
 pallet-xcm-bridge-hub = { version = "0.25.0", default-features = false }
@@ -330,7 +330,7 @@ separator = { version = "0.4.1" }
 # That 1-line member-local pin is the whole fix. See INDIVIDUALITY_STAGE0_RESULT.md §3 class (c).
 serde = { version = "1.0.214" }
 serde_json = { version = "1.0.132", default-features = false }
-smallvec = { version = "1.13.1" }
+smallvec = { version = "1.15.1" }
 snowbridge-beacon-primitives = { version = "0.21.0", default-features = false }
 snowbridge-core = { version = "0.22.0", default-features = false }
 snowbridge-merkle-tree = { version = "0.9.0", default-features = false }
@@ -384,10 +384,10 @@ substrate-wasm-builder = { version = "34.0.0" }
 system-parachains-constants = { path = "system-parachains/constants", default-features = false }
 system-parachains-common = { git = "https://github.com/polkadot-fellows/runtimes", tag = "v2.4.0", package = "system-parachains-common", default-features = false }
 tokio = { version = "1.45.0" }
-xcm = { version = "24.0.0", default-features = false, package = "staging-xcm" }
-xcm-builder = { version = "29.0.0", default-features = false, package = "staging-xcm-builder" }
+xcm = { version = "24.1.0", default-features = false, package = "staging-xcm" }
+xcm-builder = { version = "29.0.1", default-features = false, package = "staging-xcm-builder" }
 xcm-emulator = { version = "0.33.0" }
-xcm-executor = { version = "28.0.0", default-features = false, package = "staging-xcm-executor" }
+xcm-executor = { version = "28.0.1", default-features = false, package = "staging-xcm-executor" }
 xcm-runtime-apis = { version = "0.16.0", default-features = false }
 anyhow = { version = "1.0.82" }
 subxt = { version = "0.43.0" }

--- a/system-parachains/bulletin-paseo/src/lib.rs
+++ b/system-parachains/bulletin-paseo/src/lib.rs
@@ -138,21 +138,7 @@ pub mod migrations {
 	use super::*;
 
 	/// Unreleased migrations. Add new ones here:
-	///
-	/// `MigrateV6ToV7` comes with the stable2606 `cumulus-pallet-xcmp-queue`, which drops the
-	/// per-channel signal bookkeeping from `OutboundXcmpStatus`. Ordered first, matching
-	/// upstream's `bulletin-paseo`.
-	///
-	/// `RelocateFromTransactionStorage` is the one-shot move of `Renewals`,
-	/// `PendingAutoRenewals` (landing as `PendingRenewals`) and `PermanentStorageUsed` out
-	/// of the `TransactionStorage` prefix and into the new `DataRenewal` pallet's. The
-	/// source key literals keep their pre-split names. `Authorizations` is deliberately
-	/// untouched: `AuthorizationExtent::extra` occupies the slot the pre-split
-	/// `bytes_permanent` field had, so existing values already decode as the new layout.
-	pub type Unreleased = (
-		cumulus_pallet_xcmp_queue::migration::v7::MigrateV6ToV7<Runtime>,
-		pallet_bulletin_data_renewal::migrations::RelocateFromTransactionStorage<Runtime>,
-	);
+	pub type Unreleased = ();
 
 	/// Migrations/checks that do not need to be versioned and can run on every update.
 	pub type Permanent = (
@@ -1212,6 +1198,11 @@ impl_runtime_apis! {
 						fun: Fungible(ExistentialDeposit::get()),
 					}
 				}
+
+				/// `Utility::batch`, so weighing a `Transact` recurses over every nested call.
+				fn batch_call(calls: Vec<RuntimeCall>) -> Option<RuntimeCall> {
+					Some(RuntimeCall::Utility(pallet_utility::Call::<Runtime>::batch { calls }))
+				}
 			}
 
 			parameter_types! {
@@ -1321,10 +1312,10 @@ impl_runtime_apis! {
 				}
 
 				fn alias_origin() -> Result<(Location, Location), BenchmarkError> {
-					Ok((
-						Location::new(1, [Parachain(1000)]),
-						Location::new(1, [Parachain(1000), AccountId32 { id: [111u8; 32], network: None }]),
-					))
+					// Worst case: `AuthorizedAliasers`, the last and priciest `Aliasers` entry.
+					Ok(parachains_common::benchmarking::set_up_worst_case_authorized_alias::<
+						Runtime,
+					>())
 				}
 			}
 

--- a/system-parachains/bulletin-paseo/tests/upstream_compatibility.rs
+++ b/system-parachains/bulletin-paseo/tests/upstream_compatibility.rs
@@ -1,0 +1,180 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-only
+
+//! Compatibility with individuality-community v0.3.0 and the current Bulletin state.
+
+use bulletin_paseo_runtime::{
+	xcm_config::XcmConfig, DataRenewal, Executive, Runtime, RuntimeCall, RuntimeGenesisConfig,
+	System, TransactionStorage, XcmpQueue,
+};
+use codec::Encode;
+use frame_support::{assert_ok, storage::storage_prefix, traits::StorageVersion};
+use pallet_bulletin_data_renewal::{PermanentStorageUsed, RenewalData, Renewals};
+use pallet_bulletin_transaction_storage::{AuthorizationScope, Authorizations};
+use parachains_common::AccountId;
+use paseo_runtime_constants::system_parachain::{ASSET_HUB_ID, PEOPLE_ID};
+use sp_runtime::BuildStorage;
+use xcm::latest::prelude::*;
+
+fn externalities() -> sp_io::TestExternalities {
+	sp_io::TestExternalities::new(RuntimeGenesisConfig::default().build_storage().unwrap())
+}
+
+// Wire layout from individuality-community v0.3.0:
+// runtimes/next-people-paseo/src/people.rs, BulletinPallets and TransactionStorageCalls.
+// Encode independently of RuntimeCall so a Bulletin pallet/call index or argument change
+// cannot silently change both the sender fixture and receiver together.
+fn people_authorize(who: &AccountId) -> Vec<u8> {
+	(40u8, 3u8, who, 7u32, 4096u64).encode()
+}
+
+fn people_refresh(who: &AccountId) -> Vec<u8> {
+	(40u8, 7u8, who).encode()
+}
+
+fn execute_people_message(para_id: u32, call: Vec<u8>) -> Outcome {
+	let message: Xcm<RuntimeCall> = Xcm(vec![
+		UnpaidExecution { weight_limit: Unlimited, check_origin: None },
+		Transact { origin_kind: OriginKind::Xcm, fallback_max_weight: None, call: call.into() },
+		// Transact may finish XCM execution with a dispatch error in its status register.
+		ExpectTransactStatus(MaybeErrorCode::Success),
+	]);
+	xcm_executor::XcmExecutor::<XcmConfig>::prepare_and_execute(
+		Location::new(1, [Parachain(para_id)]),
+		message,
+		&mut [0u8; 32],
+		Weight::MAX,
+		Weight::zero(),
+	)
+}
+
+#[test]
+fn individuality_v0_3_0_can_allocate_and_refresh_without_resetting_usage() {
+	externalities().execute_with(|| {
+		System::set_block_number(1);
+		let who = AccountId::new([0x11; 32]);
+		let scope = AuthorizationScope::Account(who.clone());
+		assert_ok!(execute_people_message(PEOPLE_ID, people_authorize(&who)).ensure_complete());
+		let granted = Authorizations::<Runtime>::get(&scope).unwrap();
+		assert_eq!(granted.extent.transactions_allowance, 7);
+		assert_eq!(granted.extent.bytes_allowance, 4096);
+
+		// Seed an already-used allowance, including permanent bytes from DataRenewal.
+		Authorizations::<Runtime>::mutate(&scope, |authorization| {
+			let extent = &mut authorization.as_mut().unwrap().extent;
+			extent.transactions = 2;
+			extent.bytes = 512;
+			extent.extra.bytes_permanent = 1024;
+		});
+		let used = TransactionStorage::account_authorization_extent(who.clone());
+		System::set_block_number(11);
+		assert_ok!(execute_people_message(PEOPLE_ID, people_refresh(&who)).ensure_complete());
+		let refreshed = Authorizations::<Runtime>::get(&scope).unwrap();
+		assert_eq!(refreshed.expiration, granted.expiration + 10);
+		assert_eq!(refreshed.extent, used);
+	});
+}
+
+#[test]
+fn individuality_messages_from_an_unlisted_sibling_cannot_change_authorizations() {
+	externalities().execute_with(|| {
+		System::set_block_number(1);
+		let who = AccountId::new([0x11; 32]);
+		let scope = AuthorizationScope::Account(who.clone());
+		assert!(execute_people_message(2000, people_authorize(&who)).ensure_complete().is_err());
+		assert!(!Authorizations::<Runtime>::contains_key(&scope));
+
+		assert_ok!(execute_people_message(PEOPLE_ID, people_authorize(&who)).ensure_complete());
+		let before = Authorizations::<Runtime>::get(&scope).unwrap().encode();
+		System::set_block_number(11);
+		assert!(execute_people_message(2000, people_refresh(&who)).ensure_complete().is_err());
+		assert_eq!(Authorizations::<Runtime>::get(&scope).unwrap().encode(), before);
+	});
+}
+
+#[test]
+fn runtime_upgrade_preserves_current_storage() {
+	externalities().execute_with(|| {
+		System::set_block_number(1);
+		let who = AccountId::new([0x11; 32]);
+		let scope = AuthorizationScope::Account(who.clone());
+		assert_ok!(execute_people_message(PEOPLE_ID, people_authorize(&who)).ensure_complete());
+		Authorizations::<Runtime>::mutate(&scope, |authorization| {
+			let extent = &mut authorization.as_mut().unwrap().extent;
+			extent.transactions = 2;
+			extent.bytes = 512;
+			extent.extra.bytes_permanent = 1024;
+		});
+		let authorization = Authorizations::<Runtime>::get(&scope).unwrap().encode();
+
+		// Para 1010 has already completed the renewal split and XCMP v7 migration.
+		StorageVersion::new(5).put::<TransactionStorage>();
+		StorageVersion::new(1).put::<DataRenewal>();
+		StorageVersion::new(7).put::<XcmpQueue>();
+		let renewal = RenewalData { account: who, recurring: true, paid: false };
+		Renewals::<Runtime>::insert([0x22; 32], &renewal);
+		PermanentStorageUsed::<Runtime>::put(1024);
+
+		// V7: recipient, state, signals_exist, first_index, last_index, flags, queued_bytes.
+		let channels = vec![
+			(ASSET_HUB_ID, 0u8, false, 0u16, 0u16, 0u32, 0u32),
+			(PEOPLE_ID, 1u8, true, 0u16, 0u16, 3u32, 0u32),
+		]
+		.encode();
+		let channel_key = storage_prefix(b"XcmpQueue", b"OutboundXcmpStatus");
+		sp_io::storage::set(&channel_key, &channels);
+
+		for _ in 0..2 {
+			Executive::execute_on_runtime_upgrade();
+			assert_eq!(StorageVersion::get::<TransactionStorage>(), StorageVersion::new(5));
+			assert_eq!(StorageVersion::get::<DataRenewal>(), StorageVersion::new(1));
+			assert_eq!(StorageVersion::get::<XcmpQueue>(), StorageVersion::new(7));
+			assert_eq!(Renewals::<Runtime>::get([0x22; 32]), Some(renewal.clone()));
+			assert_eq!(PermanentStorageUsed::<Runtime>::get(), 1024);
+			assert_eq!(Authorizations::<Runtime>::get(&scope).unwrap().encode(), authorization);
+			assert_eq!(sp_io::storage::get(&channel_key).unwrap().to_vec(), channels);
+		}
+	});
+}
+
+#[cfg(feature = "runtime-benchmarks")]
+#[test]
+fn xcm_benchmark_batch_dispatches_every_nested_call() {
+	use bulletin_paseo_runtime::{RuntimeEvent, RuntimeOrigin};
+	use sp_runtime::traits::Dispatchable;
+
+	externalities().execute_with(|| {
+		System::set_block_number(1);
+		let calls = (0..3u8)
+			.map(|i| frame_system::Call::remark_with_event { remark: vec![i] }.into())
+			.collect();
+		let batch = <Runtime as pallet_xcm::benchmarking::Config>::batch_call(calls)
+			.expect("Transact benchmarks must weigh all nested calls");
+		assert_ok!(batch.dispatch(RuntimeOrigin::signed(AccountId::new([0x11; 32]))));
+		let remarked: Vec<_> = System::events()
+			.into_iter()
+			.filter_map(|record| match record.event {
+				RuntimeEvent::System(frame_system::Event::Remarked { hash, .. }) => Some(hash),
+				_ => None,
+			})
+			.collect();
+		let expected: Vec<_> = (0..3u8)
+			.map(|i| sp_core::H256::from(sp_io::hashing::blake2_256(&[i])))
+			.collect();
+		assert_eq!(remarked, expected);
+	});
+}
+
+#[cfg(feature = "runtime-benchmarks")]
+#[test]
+fn xcm_alias_benchmark_exercises_authorized_aliasers() {
+	use frame_support::traits::ContainsPair;
+
+	externalities().execute_with(|| {
+		System::set_block_number(1);
+		let (origin, target) =
+			<Runtime as pallet_xcm_benchmarks::generic::Config>::alias_origin().unwrap();
+		assert!(pallet_xcm::AuthorizedAliasers::<Runtime>::contains(&origin, &target));
+		assert!(<XcmConfig as xcm_executor::Config>::Aliasers::contains(&origin, &target));
+	});
+}


### PR DESCRIPTION
Complete the remaining Bulletin sync on top of `sync-upstream`, which already includes the v0.0.26 pallets and DataRenewal.

- Align XCM and smallvec minimum versions with [v0.0.26-paseo](https://github.com/paritytech/polkadot-bulletin-chain/releases/tag/v0.0.26-paseo).
- Remove completed XCMP v7 and DataRenewal migrations, following upstream [#758](https://github.com/paritytech/polkadot-bulletin-chain/pull/758).
- Port nested-batch `Transact` and worst-case authorized-alias benchmark setup from upstream [#768](https://github.com/paritytech/polkadot-bulletin-chain/pull/768).
- Add tests for [Individuality v0.3.0](https://github.com/paritytech/individuality-community/releases#release-v0.3.0) authorization/refresh messages, upgrade storage preservation and both benchmark helpers.

Paseo-specific configuration and weights remain unchanged.

Validation: 49 runtime tests passed; 5 compatibility tests passed with `try-runtime,runtime-benchmarks`; Wasm build, formatting and `git diff --check` passed.
